### PR TITLE
Use a CMake find script for Poco libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,26 +1,13 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(abb_librws)
 
-find_package(catkin REQUIRED)
+find_package(catkin REQUIRED COMPONENTS cmake_modules)
 
 ########################
 ## POCO C++ Libraries ##
 ########################
-set(Poco_HINT /usr/local)
-find_path(Poco_INCLUDE_DIRS Poco/Poco.h HINTS Poco_HINT)
-find_library(Poco_NET PocoNet HINTS Poco_HINT)
-find_library(Poco_UTIL PocoUtil HINTS Poco_HINT)
-find_library(Poco_FOUNDATION PocoFoundation HINTS Poco_HINT)
-find_library(Poco_XML PocoXML HINTS Poco_HINT)
-set(Poco_LIBRARIES ${Poco_NET} ${Poco_UTIL} ${Poco_FOUNDATION} ${Poco_XML})
-
-if(NOT Poco_INCLUDE_DIRS)
-  message(FATAL_ERROR "Cannot find required 'POCO C++ Libraries' include directory. Aborting.")
-endif()
-
-if(NOT Poco_NET OR NOT Poco_UTIL OR NOT Poco_FOUNDATION OR NOT Poco_XML)
-  message(FATAL_ERROR "Cannot find required 'POCO C++ Libraries'. Aborting.")
-endif()
+# we need at least 1.4.3 because of websocket support
+find_package(Poco 1.4.3 REQUIRED COMPONENTS Net Util Foundation XML)
 
 ###################################
 ## catkin specific configuration ##

--- a/include/abb_librws/rws_common.h
+++ b/include/abb_librws/rws_common.h
@@ -38,6 +38,7 @@
 #define RWS_COMMON_H
 
 #include <string>
+#include <vector>
 
 #include "Poco/DOM/AutoPtr.h"
 #include "Poco/DOM/Document.h"

--- a/package.xml
+++ b/package.xml
@@ -11,4 +11,7 @@
   <author email="jon.tjerngren@se.abb.com">Jon Tjerngren</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>cmake_modules</build_depend>
+  <build_depend version_gte="1.4.3">libpoco-dev</build_depend>
 </package>


### PR DESCRIPTION
Instead of manually searching for the components using `find_path(..)` and `find_library(..)`.

e1c8dba also adds a missing header include that I needed to add to get the build to succeed. I'd normally not include that in a PR that changes build infrastructure, but this is really minor and I'd like to avoid opening a lot of 'trivial' PRs.
