### PR TITLE
Bump cmake_minimum_required to 2.8.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 2.8.12)
 project(abb_librws)
 
 find_package(catkin REQUIRED COMPONENTS cmake_modules)


### PR DESCRIPTION
For consistency with abb_libegm, see https://github.com/ros-industrial/abb_libegm/commit/2977bf1e50cb24d619dc431190ae6efe47743b8b and the relative discussion https://github.com/ros-industrial/abb_libegm/pull/14 .