### PR TITLE
Simplified subscription usage and updated the TriBool implementation

### DIFF
--- a/include/abb_librws/rws_common.h
+++ b/include/abb_librws/rws_common.h
@@ -660,6 +660,194 @@ struct SystemConstants
   };
 };
 
+/**
+ * \brief A class for a tri value bool.
+ */
+class TriBool
+{
+public:
+  /**
+   * \brief An enum for the different accepted values.
+   */
+  enum Values
+  {
+    UNKNOWN_VALUE, ///< Unknown value. E.g. in case of communication failure.
+    TRUE_VALUE,    ///< True value.
+    FALSE_VALUE    ///< False value.
+  };
+
+  /**
+   * \brief A default constructor.
+   */
+  TriBool() : value(UNKNOWN_VALUE) {}
+
+  /**
+   * \brief A constructor.
+   */
+  TriBool(const Values initial_value) : value(initial_value) {}
+
+  /**
+   * \brief A constructor.
+   *
+   * \param value for the initial true or false value.
+   */
+  TriBool(const bool initial_value) : value(initial_value ? TRUE_VALUE : FALSE_VALUE) {}
+
+  /**
+   * \brief Operator for copy assignment.
+   *
+   * \param rhs for right hand side value.
+   *
+   * \return TriBool& self.
+   */
+  TriBool& operator=(const TriBool& other)
+  {
+    if (&other == this)
+    {
+      return *this;
+    }
+
+    value = other.value;
+
+    return *this;
+  }
+
+  /**
+   * \brief Operator for assignment.
+   *
+   * \param rhs for right hand side value.
+   *
+   * \return TriBool& self.
+   */
+  TriBool& operator=(const Values& rhs)
+  {
+    value = rhs;
+
+    return *this;
+  }
+
+  /**
+   * \brief Operator for assignment.
+   *
+   * \param rhs for right hand side value.
+   *
+   * \return TriBool& self.
+   */
+  TriBool& operator=(const bool& rhs)
+  {
+    value = (rhs ? TRUE_VALUE : FALSE_VALUE);
+
+    return *this;
+  }
+
+  /**
+   * \brief Operator for equal to comparison.
+   *
+   * \param rhs for right hand side value.
+   *
+   * \return bool indicating if the comparision was equal or not.
+   */
+  bool operator==(const TriBool& rhs) const
+  {
+    return value == rhs.value;
+  }
+
+  /**
+   * \brief Operator for equal to comparison.
+   *
+   * \param rhs for right hand side value.
+   *
+   * \return bool indicating if the comparision was equal or not.
+   */
+  bool operator==(const Values& rhs) const
+  {
+    return value == rhs;
+  }
+
+  /**
+   * \brief Operator for not equal to comparison.
+   *
+   * \param rhs for right hand side value.
+   *
+   * \return bool indicating if the comparision was not equal or not.
+   */
+  bool operator!=(const TriBool& rhs) const
+  {
+    return value != rhs.value;
+  }
+
+  /**
+   * \brief Operator for not equal to comparison.
+   *
+   * \param rhs for right hand side value.
+   *
+   * \return bool indicating if the comparision was not equal or not.
+   */
+  bool operator!=(const Values& rhs) const
+  {
+    return value != rhs;
+  }
+
+  /**
+   * \brief Operator for stream insertion.
+   *
+   * \param stream for the output stream.
+   * \param rhs for the right hand side value, to insert into the output stream.
+   *
+   * \return std::ostream& for the output stream.
+   */
+  friend std::ostream& operator<<(std::ostream& stream, const TriBool& rhs)
+  {
+    return stream << rhs.toString();
+  }
+
+  /**
+   * \brief A method for checking if the tri bool is unknown.
+   *
+   * \return bool indicating if the tri bool is unknown or not.
+   */
+  bool isUnknown() const
+  {
+    return value == UNKNOWN_VALUE;
+  }
+
+  /**
+   * \brief A method for checking if the tri bool is true.
+   *
+   * \return bool indicating if the tri bool is true or not.
+   */
+  bool isTrue() const
+  {
+    return value == TRUE_VALUE;
+  }
+
+  /**
+   * \brief A method for checking if the tri bool is false.
+   *
+   * \return bool indicating if the tri bool is false or not.
+   */
+  bool isFalse() const
+  {
+    return value == FALSE_VALUE;
+  }
+
+  /**
+   * \brief A method for converting the tri bool to a text string.
+   *
+   * \return std::string containing the string representation of the value.
+   */
+  std::string toString() const
+  {
+    return (isUnknown() ? "unknown" : (isTrue() ? "true" : "false"));
+  }
+
+private:
+  /**
+   * \brief The tri bool value.
+   */
+  Values value;
+};
+
 } // end namespace rws
 } // end namespace abb
 

--- a/include/abb_librws/rws_interface.h
+++ b/include/abb_librws/rws_interface.h
@@ -50,167 +50,6 @@ class RWSInterface
 {
 public:
   /**
-   * \brief A struct for a tri value bool.
-   */
-  struct TriBool
-  {
-    /**
-     * \brief An enum for the different accepted values.
-     */
-    enum Values
-    {
-      UNKNOWN_VALUE, ///< Unknown value. E.g. in case of communication failure.
-      TRUE_VALUE,    ///< True value.
-      FALSE_VALUE    ///< False value.
-    };
-    
-    /**
-     * \brief A default constructor.
-     */
-    TriBool() : value(UNKNOWN_VALUE) {}
-    
-    /**
-     * \brief A constructor.
-     *
-     * \param value for the initial true or false value.
-     */
-    TriBool(const bool initial_value) : value(initial_value ? TRUE_VALUE : FALSE_VALUE) {}
-
-    /**
-     * \brief Operator for conversion to a bool.
-     *
-     * \return bool returns true if the value is TRUE_VALUE, otherwise false.
-     */
-    operator bool() const
-    {
-      return value == TRUE_VALUE;
-    }
-    
-    /**
-     * \brief Operator for copy assignment.
-     *
-     * \param rhs for right hand side value.
-     *
-     * \return TriBool& self.
-     */
-    TriBool& operator=(const TriBool& other)
-    {
-      if (&other == this)
-      {
-        return *this;
-      }
-
-      value = other.value;
-
-      return *this;
-    }
-    
-    /**
-     * \brief Operator for assignment.
-     *
-     * \param rhs for right hand side value.
-     *
-     * \return TriBool& self.
-     */
-    TriBool& operator=(const Values& rhs)
-    {
-      value = rhs;
-
-      return *this;
-    }
-    
-    /**
-     * \brief Operator for assignment.
-     *
-     * \param rhs for right hand side value.
-     *
-     * \return TriBool& self.
-     */
-    TriBool& operator=(const bool& rhs)
-    {
-      value = (rhs ? TRUE_VALUE : FALSE_VALUE);
-
-      return *this;
-    }
-
-    /**
-     * \brief Operator for equal to comparison.
-     *
-     * \param rhs for right hand side value.
-     *
-     * \return bool indicating if the comparision was equal or not.
-     */
-    bool operator==(const TriBool& rhs) const
-    {
-      return value == rhs.value;
-    }
-    
-    /**
-     * \brief Operator for equal to comparison.
-     *
-     * \param rhs for right hand side value.
-     *
-     * \return bool indicating if the comparision was equal or not.
-     */
-    bool operator==(const Values& rhs) const
-    {
-      return value == rhs;
-    }
-
-    /**
-     * \brief Operator for not equal to comparison.
-     *
-     * \param rhs for right hand side value.
-     *
-     * \return bool indicating if the comparision was not equal or not.
-     */
-    bool operator!=(const TriBool& rhs) const
-    {
-      return value != rhs.value;
-    }
-    
-    /**
-     * \brief Operator for not equal to comparison.
-     *
-     * \param rhs for right hand side value.
-     *
-     * \return bool indicating if the comparision was not equal or not.
-     */
-    bool operator!=(const Values& rhs) const
-    {
-      return value != rhs;
-    }
-
-    /**
-     * \brief Operator for stream insertion.
-     *
-     * \param stream for the output stream.
-     * \param rhs for the right hand side value, to insert into the output stream.
-     *
-     * \return std::ostream& for the output stream.
-     */
-    friend std::ostream& operator<<(std::ostream& stream, const TriBool& rhs)
-    {
-      return stream << rhs.toString();
-    }
-
-    /**
-     * \brief A method for converting the tri bool to a text string.
-     *
-     * \return std::string containing the string representation of the value.
-     */
-    std::string toString() const
-    {
-      return (value == UNKNOWN_VALUE ? "unknown" : (value == TRUE_VALUE ? "true" : "false"));
-    }
-
-    /**
-     * \brief The tri bool value.
-     */
-    Values value;
-  };
-  
-  /**
    * \brief A struct for containing system information of the robot controller.
    */
   struct SystemInfo
@@ -580,9 +419,16 @@ public:
    * \return bool indicating if the communication was successful or not.
    */
   bool startSubscription(const RWSClient::SubscriptionResources resources);
-      
+
   /**
-   * \brief A method for waiting for a subscription event.
+   * \brief A method for waiting for a subscription event (use if the event content is irrelevant).
+   *
+   * \return bool indicating if the communication was successful or not.
+   */
+  bool waitForSubscriptionEvent();
+
+  /**
+   * \brief A method for waiting for a subscription event (use if the event content is important). 
    *
    * \param p_xml_document for storing the data received in the subscription event.
    *

--- a/include/abb_librws/rws_poco_client.h
+++ b/include/abb_librws/rws_poco_client.h
@@ -326,7 +326,7 @@ public:
    * \brief A method for connecting a WebSocket.
    *
    * \param uri for the URI (path and query).
-   * \param uri for the WebSocket protocol.
+   * \param protocol for the WebSocket protocol.
    *
    * \return POCOResult containing the result.
    */

--- a/src/rws_interface.cpp
+++ b/src/rws_interface.cpp
@@ -242,21 +242,21 @@ RWSInterface::SystemInfo RWSInterface::getSystemInfo()
   return result;
 }
 
-RWSInterface::TriBool RWSInterface::isAutoMode()
+TriBool RWSInterface::isAutoMode()
 {
   return compareSingleContent(rws_client_.getPanelOperationMode(),
                               XMLAttributes::CLASS_OPMODE,
                               ContollerStates::PANEL_OPERATION_MODE_AUTO);
 }
 
-RWSInterface::TriBool RWSInterface::isMotorOn()
+TriBool RWSInterface::isMotorOn()
 {
   return compareSingleContent(rws_client_.getPanelControllerState(),
                               XMLAttributes::CLASS_CTRLSTATE,
                               ContollerStates::CONTROLLER_MOTOR_ON);
 }
 
-RWSInterface::TriBool RWSInterface::isRAPIDRunning()
+TriBool RWSInterface::isRAPIDRunning()
 {
   return compareSingleContent(rws_client_.getRAPIDExecution(),
                               XMLAttributes::CLASS_CTRLEXECSTATE,
@@ -301,6 +301,13 @@ bool RWSInterface::deleteFile(const RWSClient::FileResource resource)
 bool RWSInterface::startSubscription (RWSClient::SubscriptionResources resources)
 {
   return rws_client_.startSubscription(resources).success;
+}
+
+bool RWSInterface::waitForSubscriptionEvent()
+{
+  RWSClient::RWSResult rws_result = rws_client_.waitForSubscriptionEvent();
+
+  return (rws_result.success && !rws_result.p_xml_document.isNull());
 }
 
 bool RWSInterface::waitForSubscriptionEvent(Poco::AutoPtr<Poco::XML::Document>* p_xml_document)
@@ -349,9 +356,9 @@ std::string RWSInterface::getLogText(const bool verbose)
  * Auxiliary methods
  */
 
-RWSInterface::TriBool RWSInterface::compareSingleContent(const RWSClient::RWSResult& rws_result,
-                                                         const XMLAttribute& attribute,
-                                                         const std::string& compare_string)
+TriBool RWSInterface::compareSingleContent(const RWSClient::RWSResult& rws_result,
+                                           const XMLAttribute& attribute,
+                                           const std::string& compare_string)
 {
   TriBool result;
 

--- a/src/rws_poco_client.cpp
+++ b/src/rws_poco_client.cpp
@@ -333,7 +333,7 @@ POCOClient::POCOResult POCOClient::webSocketConnect(const std::string uri, const
   {
     result.addHTTPRequestInfo(request);
     p_websocket_ = new WebSocket(client_session_, request, response);
-    p_websocket_->setReceiveTimeout(Poco::Timespan(60000000));
+    p_websocket_->setReceiveTimeout(Poco::Timespan(LONG_TIMEOUT));
       
     result.addHTTPResponseInfo(response);
     result.status = POCOResult::OK;

--- a/src/rws_simple_state_machine_interface.cpp
+++ b/src/rws_simple_state_machine_interface.cpp
@@ -107,9 +107,9 @@ bool RWSSimpleStateMachineInterface::goToHomePosition(const std::string task)
   return signalRunRAPIDRoutine(task, "goToHomePosition");
 }
 
-RWSInterface::TriBool RWSSimpleStateMachineInterface::isStateIdle(const std::string task)
+TriBool RWSSimpleStateMachineInterface::isStateIdle(const std::string task)
 {
-  RWSInterface::TriBool result;
+  TriBool result;
 
   RAPIDAtomic<RAPID_NUM> current_state;
   if(getRAPIDSymbolData(task, ProgramConstants::RAPID::Symbols::CURRENT_STATE, &current_state))
@@ -120,9 +120,9 @@ RWSInterface::TriBool RWSSimpleStateMachineInterface::isStateIdle(const std::str
   return result;
 }
 
-RWSInterface::TriBool RWSSimpleStateMachineInterface::isStationary(const std::string mechanical_unit)
+TriBool RWSSimpleStateMachineInterface::isStationary(const std::string mechanical_unit)
 {
-  RWSInterface::TriBool result;
+  TriBool result;
 
   std::string temp = getIOSignal(ProgramConstants::IOSignals::OUTPUT_STATIONARY + "_" + mechanical_unit);
 
@@ -178,7 +178,7 @@ bool RWSSimpleStateMachineInterface::toggleIOSignal(const std::string iosignal)
   bool result = false;
   int max_number_of_attempts = 5;
 
-  if (isAutoMode())
+  if (isAutoMode().isTrue())
   {
     for (int i = 0; i < max_number_of_attempts && !result; ++i)
     {


### PR DESCRIPTION
- Simplified the RWS subscription usage for when the event content is inconsequential (part of issue https://github.com/ros-industrial/abb_librws/issues/24)

- Updated the TriBool according to:
  - Moved the implementation from inside the RWSInterface class to rws_common.h.
**Reason:** TriBool is useful outside of the RWSInterface class, and doesn't really have anything to do with the class per se.
  - Removed the implicit bool conversion operator, and implemented methods to check certain cases instead.
**Reason:** The implicit bool conversion resulted in the following unintended behavior:
`TriBool tri_bool(TriBool::FALSE_VALUE);`
`tri_bool == TriBool::UNKNOWN_VALUE // Resulted in false. Ok!`
`TriBool::UNKNOWN_VALUE == tri_bool // Resulted in true. Not ok!`