### PR TITLE
Renamed methods and updated comments

### DIFF
--- a/include/abb_librws/rws_interface.h
+++ b/include/abb_librws/rws_interface.h
@@ -135,7 +135,7 @@ public:
     TriBool rapid_running;
     
     /**
-     * \brief Indicator for RWS is connected to the robot controller system.
+     * \brief Indicator for if RWS is connected to the robot controller system.
      */
     bool rws_connected;
   };

--- a/include/abb_librws/rws_rapid.h
+++ b/include/abb_librws/rws_rapid.h
@@ -71,18 +71,18 @@ public:
   virtual std::string getType() const = 0;
   
   /**
-   * \brief Pure virtual method for parsing a RWS RAPID symbol data value string.
+   * \brief Pure virtual method for parsing a RAPID symbol data value string.
    * 
    * \param value_string containing the string to parse.
    */
-  virtual void parseRWSValueString(const std::string&  value_string) = 0;
+  virtual void parseString(const std::string&  value_string) = 0;
 
   /**
-   * \brief Pure virtual method for constructing a RWS symbol data value string.
+   * \brief Pure virtual method for constructing a RAPID symbol data value string.
    * 
    * \return std::string containing the constructed string.
    */
-  virtual std::string constructRWSValueString() const = 0;
+  virtual std::string constructString() const = 0;
 };
 
 /**
@@ -93,11 +93,11 @@ struct RAPIDAtomicTemplate : public RAPIDSymbolDataAbstract
 {
 public:
   /**
-   * \brief A method for parsing a RWS RAPID symbol data value string.
+   * \brief A method for parsing a RAPID symbol data value string.
    * 
    * \param value_string containing the string to parse.
    */
-  void parseRWSValueString(const std::string& value_string)
+  void parseString(const std::string& value_string)
   {
     std::stringstream ss(value_string);
     ss >> value;
@@ -141,20 +141,20 @@ struct RAPIDAtomic<RAPID_BOOL> : public RAPIDAtomicTemplate<bool>
    * \return std::string containing the data type name.
    */
   std::string getType() const;
-  
+
   /**
-   * \brief A method for parsing a RWS RAPID symbol data value string.
-   * 
+   * \brief A method for parsing a RAPID symbol data value string.
+   *
    * \param value_string containing the string to parse.
    */
-  void parseRWSValueString(const std::string& value_string);
+  void parseString(const std::string& value_string);
   
   /**
-   * \brief A method for constructing a RWS symbol data value string.
-   * 
+   * \brief A method for constructing a RAPID symbol data value string.
+   *
    * \return std::string containing the constructed string.
    */
-  std::string constructRWSValueString() const;
+  std::string constructString() const;
 };
 
 /**
@@ -178,11 +178,11 @@ struct RAPIDAtomic<RAPID_NUM> : public RAPIDAtomicTemplate<float>
   std::string getType() const;
   
   /**
-   * \brief A method for constructing a RWS symbol data value string.
-   * 
+   * \brief A method for constructing a RAPID symbol data value string.
+   *
    * \return std::string containing the constructed string.
    */
-  std::string constructRWSValueString() const;
+  std::string constructString() const;
 };
 
 /**
@@ -204,13 +204,13 @@ struct RAPIDAtomic<RAPID_DNUM> : public RAPIDAtomicTemplate<double>
    * \return std::string containing the data type name.
    */
   std::string getType() const;
-  
+
   /**
-   * \brief A method for constructing a RWS symbol data value string.
-   * 
+   * \brief A method for constructing a RAPID symbol data value string.
+   *
    * \return std::string containing the constructed string.
    */
-  std::string constructRWSValueString() const;
+  std::string constructString() const;
 };
 
 /**
@@ -234,18 +234,18 @@ struct RAPIDAtomic<RAPID_STRING> : public RAPIDAtomicTemplate<std::string>
   std::string getType() const;
   
   /**
-   * \brief A method for parsing a RWS RAPID symbol data value string.
-   * 
+   * \brief A method for parsing a RAPID symbol data value string.
+   *
    * \param value_string containing the string to parse.
    */
-  void parseRWSValueString(const std::string& value_string);
+  void parseString(const std::string& value_string);
 
   /**
-   * \brief A method for constructing a RWS symbol data value string.
-   * 
+   * \brief A method for constructing a RAPID symbol data value string.
+   *
    * \return std::string containing the constructed string.
    */
-  std::string constructRWSValueString() const;
+  std::string constructString() const;
 };
 
 /**
@@ -282,18 +282,18 @@ public:
   RAPIDRecord(const std::string record_type_name);
   
   /**
-   * \brief A method for constructing the RWS value string for the record. E.g. for sending to the controller via RWS.
+   * \brief A method for constructing a RAPID symbol data value string.
    *
-   * \return std::string containing the RWS value string.
+   * \return std::string containing the constructed string.
    */
-  std::string constructRWSValueString() const;
+  std::string constructString() const;
   
   /**
-   * \brief A method for parsing a received RAPID value string.
-   * 
-   * \param value_string containing the received RWS value string.
+   * \brief A method for parsing a RAPID symbol data value string.
+   *
+   * \param value_string containing the string to parse.
    */
-  void parseRWSValueString(const std::string& value_string);
+  void parseString(const std::string& value_string);
   
   /**
    * \brief A method for getting the type of the RAPID record.

--- a/src/rws_client.cpp
+++ b/src/rws_client.cpp
@@ -224,7 +224,7 @@ RWSClient::RWSResult RWSClient::getRAPIDSymbolData(const RAPIDResource resource,
 
           if (!value.empty())
           {
-            p_data->parseRWSValueString(value);
+            p_data->parseString(value);
           }
           else
           {
@@ -275,7 +275,7 @@ RWSClient::RWSResult RWSClient::setRAPIDSymbolData(const RAPIDResource resource,
 
 RWSClient::RWSResult RWSClient::setRAPIDSymbolData(const RAPIDResource resource, RAPIDSymbolDataAbstract& data)
 {
-  return setRAPIDSymbolData(resource, data.constructRWSValueString());
+  return setRAPIDSymbolData(resource, data.constructString());
 }
 
 RWSClient::RWSResult RWSClient::startRAPIDExecution()

--- a/src/rws_interface.cpp
+++ b/src/rws_interface.cpp
@@ -122,7 +122,7 @@ bool RWSInterface::getMechanicalUnitJointTarget(const std::string mechunit, Join
          << xmlFindTextContent(rws_result.p_xml_document, XMLAttribute("class", "eax_e")) << ","
          << xmlFindTextContent(rws_result.p_xml_document, XMLAttribute("class", "eax_f")) << "]]";
 
-      p_jointtarget->parseRWSValueString(ss.str());
+      p_jointtarget->parseString(ss.str());
     }
   }
 
@@ -161,7 +161,7 @@ bool RWSInterface::getMechanicalUnitRobTarget(const std::string mechunit, RobTar
          << xmlFindTextContent(rws_result.p_xml_document, XMLAttribute("class", "eax_e")) << ","
          << xmlFindTextContent(rws_result.p_xml_document, XMLAttribute("class", "eax_f")) << "]]";
 
-      p_robtarget->parseRWSValueString(ss.str());
+      p_robtarget->parseString(ss.str());
     }
   }
 

--- a/src/rws_rapid.cpp
+++ b/src/rws_rapid.cpp
@@ -74,12 +74,12 @@ std::string RAPIDAtomic<RAPID_STRING>::getType() const
   return RAPID::TYPE_STRING;
 }
 
-std::string RAPIDAtomic<RAPID_BOOL>::constructRWSValueString() const
+std::string RAPIDAtomic<RAPID_BOOL>::constructString() const
 {
   return (value ? RAPID::RAPID_TRUE : RAPID::RAPID_FALSE);
 }
 
-std::string RAPIDAtomic<RAPID_NUM>::constructRWSValueString() const
+std::string RAPIDAtomic<RAPID_NUM>::constructString() const
 {
   std::string result("9000000000");
 
@@ -93,7 +93,7 @@ std::string RAPIDAtomic<RAPID_NUM>::constructRWSValueString() const
   return result;
 }
 
-std::string RAPIDAtomic<RAPID_DNUM>::constructRWSValueString() const
+std::string RAPIDAtomic<RAPID_DNUM>::constructString() const
 {
   std::string result("9000000000");
 
@@ -107,17 +107,17 @@ std::string RAPIDAtomic<RAPID_DNUM>::constructRWSValueString() const
   return result;
 }
 
-std::string RAPIDAtomic<RAPID_STRING>::constructRWSValueString() const
+std::string RAPIDAtomic<RAPID_STRING>::constructString() const
 {
   return "\"" + value + "\"";
 }
 
-void RAPIDAtomic<RAPID_BOOL>::parseRWSValueString(const std::string& value_string)
+void RAPIDAtomic<RAPID_BOOL>::parseString(const std::string& value_string)
 {
   value = value_string.compare(RAPID::RAPID_TRUE) == 0 ? true : false;
 }
 
-void RAPIDAtomic<RAPID_STRING>::parseRWSValueString(const std::string& value_string)
+void RAPIDAtomic<RAPID_STRING>::parseString(const std::string& value_string)
 {
   std::string temp = value_string;
 
@@ -157,7 +157,7 @@ std::string RAPIDRecord::getType() const
   return record_type_name_;
 }
 
-void RAPIDRecord::parseRWSValueString(const std::string& value_string)
+void RAPIDRecord::parseString(const std::string& value_string)
 {
   std::vector<std::string> substrings = extractDelimitedSubstrings(value_string);
 
@@ -165,12 +165,12 @@ void RAPIDRecord::parseRWSValueString(const std::string& value_string)
   {
     for (size_t i = 0; i < components_.size(); ++i)
     {
-      components_.at(i)->parseRWSValueString(substrings.at(i));
+      components_.at(i)->parseString(substrings.at(i));
     }
   }
 }
 
-std::string RAPIDRecord::constructRWSValueString() const
+std::string RAPIDRecord::constructString() const
 {
   std::stringstream ss;
 
@@ -178,7 +178,7 @@ std::string RAPIDRecord::constructRWSValueString() const
 
   for (size_t i = 0; i < components_.size(); ++i)
   {
-    ss << components_.at(i)->constructRWSValueString();
+    ss << components_.at(i)->constructString();
 
     if (i != components_.size() - 1)
     {
@@ -201,7 +201,7 @@ RAPIDRecord& RAPIDRecord::operator=(const RAPIDRecord& other)
       {
         for (size_t i = 0; i < components_.size(); ++i)
         {
-          components_.at(i)->parseRWSValueString(other.components_.at(i)->constructRWSValueString());
+          components_.at(i)->parseString(other.components_.at(i)->constructString());
         }
       }
     }


### PR DESCRIPTION
Reason for the change is that the previous implementation was a bit misleading.