### PR TITLE
Migrated to the latest RobotWare and renamed the HTTPClientSession

### DIFF
--- a/include/abb_librws/rws_client.h
+++ b/include/abb_librws/rws_client.h
@@ -81,6 +81,11 @@ public:
     Poco::AutoPtr<Poco::XML::Document> p_xml_document;
 
     /**
+     * \brief Container for an error message (if one occured).
+     */
+    std::string error_message;
+
+    /**
      * \brief A default constructor.
      */
     RWSResult() : success(false) {}

--- a/include/abb_librws/rws_poco_client.h
+++ b/include/abb_librws/rws_poco_client.h
@@ -179,8 +179,8 @@ public:
     GeneralStatus status;
 
     /**
-    * \brief Container for an exception message (if one occured).
-    */
+     * \brief Container for an exception message (if one occured).
+     */
     std::string exception_message;
 
     /**

--- a/include/abb_librws/rws_poco_client.h
+++ b/include/abb_librws/rws_poco_client.h
@@ -255,11 +255,11 @@ public:
              const std::string username,
              const std::string password)
   :
-  client_session_(ip_address, port),
+  http_client_session_(ip_address, port),
   http_credentials_(username, password)
   {
-    client_session_.setKeepAlive(true);
-    client_session_.setTimeout(Poco::Timespan(DEFAULT_TIMEOUT));
+    http_client_session_.setKeepAlive(true);
+    http_client_session_.setTimeout(Poco::Timespan(DEFAULT_TIMEOUT));
   }
 
   /**
@@ -308,12 +308,12 @@ public:
   /**
    * \brief A method for resetting the timeout to the default value.
    */
-  void resetTimeout() { client_session_.setTimeout(Poco::Timespan(DEFAULT_TIMEOUT)); }
+  void resetTimeout() { http_client_session_.setTimeout(Poco::Timespan(DEFAULT_TIMEOUT)); }
   
   /**
    * \brief A method for setting the timeout to a long value.
    */
-  void setLongTimeout() { client_session_.setTimeout(Poco::Timespan(LONG_TIMEOUT)); }
+  void setLongTimeout() { http_client_session_.setTimeout(Poco::Timespan(LONG_TIMEOUT)); }
 
   /**
    * \brief A method for checking if the WebSocket exist.
@@ -437,7 +437,7 @@ private:
   /**
    * \brief A HTTP client session.
    */
-  Poco::Net::HTTPClientSession client_session_;
+  Poco::Net::HTTPClientSession http_client_session_;
   
   /**
    * \brief A buffer for a WebSocket.

--- a/src/rws_client.cpp
+++ b/src/rws_client.cpp
@@ -382,6 +382,7 @@ RWSClient::RWSResult RWSClient::deleteFile(const FileResource resource)
   evaluation_conditions_.reset();
   evaluation_conditions_.parse_message_into_xml = false;
   evaluation_conditions_.accepted_outcomes.push_back(HTTPResponse::HTTP_OK);
+  evaluation_conditions_.accepted_outcomes.push_back(HTTPResponse::HTTP_NO_CONTENT);
 
   return evaluatePOCOResult(httpDelete(uri_), evaluation_conditions_);
 }

--- a/src/rws_client.cpp
+++ b/src/rws_client.cpp
@@ -229,6 +229,7 @@ RWSClient::RWSResult RWSClient::getRAPIDSymbolData(const RAPIDResource resource,
           else
           {
             result.success = false;
+            result.error_message = "getRAPIDSymbolData(...): RAPID value string was empty";
           }
         }
       }
@@ -554,6 +555,11 @@ void RWSClient::checkAcceptedOutcomes(RWSResult* result,
       {
         result->success = (poco_result.poco_info.http.response.status == conditions.accepted_outcomes.at(i));
       }
+
+      if (!result->success)
+      {
+        result->error_message = "checkAcceptedOutcomes(...): RWS response status not accepted";
+      }
     }
   }
 }
@@ -576,6 +582,7 @@ void RWSClient::parseMessage(RWSResult* result, const POCOResult& poco_result)
     {
       // XML parsing: Missing message
       result->success = false;
+      result->error_message = "parseMessage(...): RWS response was empty";
     }
 
     if (result->success)
@@ -589,6 +596,7 @@ void RWSClient::parseMessage(RWSResult* result, const POCOResult& poco_result)
       {
         // XML parsing: Failed
         result->success = false;
+        result->error_message = "parseMessage(...): XML parser failed to parse RWS response";
       }
     }
   }

--- a/src/rws_poco_client.cpp
+++ b/src/rws_poco_client.cpp
@@ -276,7 +276,7 @@ POCOClient::POCOResult POCOClient::makeHTTPRequest(const std::string method,
     // Check if there was a server error, if so, make another attempt with a clean sheet.
     if (response.getStatus() >= HTTPResponse::HTTP_INTERNAL_SERVER_ERROR)
     {
-      client_session_.reset();
+      http_client_session_.reset();
       request.erase(HTTPRequest::COOKIE);
       sendAndReceive(result, request, response, content);
     }
@@ -308,7 +308,7 @@ POCOClient::POCOResult POCOClient::makeHTTPRequest(const std::string method,
   if (result.status != POCOResult::OK)
   {
     cookies_.clear();
-    client_session_.reset();
+    http_client_session_.reset();
   }
 
   return result;
@@ -332,7 +332,7 @@ POCOClient::POCOResult POCOClient::webSocketConnect(const std::string uri, const
   try
   {
     result.addHTTPRequestInfo(request);
-    p_websocket_ = new WebSocket(client_session_, request, response);
+    p_websocket_ = new WebSocket(http_client_session_, request, response);
     p_websocket_->setReceiveTimeout(Poco::Timespan(LONG_TIMEOUT));
       
     result.addHTTPResponseInfo(response);
@@ -361,7 +361,7 @@ POCOClient::POCOResult POCOClient::webSocketConnect(const std::string uri, const
 
   if (result.status != POCOResult::OK)
   {
-    client_session_.reset();
+    http_client_session_.reset();
   }
 
   return result;
@@ -443,7 +443,7 @@ POCOClient::POCOResult POCOClient::webSocketRecieveFrame()
 
   if (result.status != POCOResult::OK)
   {
-    client_session_.reset();
+    http_client_session_.reset();
   }
 
   return result;
@@ -463,8 +463,8 @@ void POCOClient::sendAndReceive(POCOResult& result,
 
   // Contact the server.
   std::string response_content;
-  client_session_.sendRequest(request) << request_content;
-  StreamCopier::copyToString(client_session_.receiveResponse(response), response_content);
+  http_client_session_.sendRequest(request) << request_content;
+  StreamCopier::copyToString(http_client_session_.receiveResponse(response), response_content);
 
   // Add response info to the result.
   result.addHTTPResponseInfo(response, response_content);


### PR DESCRIPTION
* Minor update to be able to use latest RobotWare
* Added an extra error message field to the communication result
* Renamed the HTTPClientSession instance (for clarity)

Solves issue https://github.com/ros-industrial/abb_librws/issues/22