### PR TITLE
Updated communication timeouts

### DIFF
--- a/include/abb_librws/rws_client.h
+++ b/include/abb_librws/rws_client.h
@@ -707,6 +707,11 @@ private:
   static const size_t LOG_SIZE = 20;
 
   /**
+   * \brief Static constant for the default RWS subscription timeout [microseconds].
+   */
+  static const Poco::Int64 DEFAULT_SUBSCRIPTION_TIMEOUT = 40000000;
+
+  /**
    * \brief Container for logging communication results.
    */
   std::deque<POCOResult> log_;

--- a/include/abb_librws/rws_client.h
+++ b/include/abb_librws/rws_client.h
@@ -709,7 +709,7 @@ private:
   /**
    * \brief Static constant for the default RWS subscription timeout [microseconds].
    */
-  static const Poco::Int64 DEFAULT_SUBSCRIPTION_TIMEOUT = 40000000;
+  static const Poco::Int64 DEFAULT_SUBSCRIPTION_TIMEOUT = 40e6;
 
   /**
    * \brief Container for logging communication results.

--- a/include/abb_librws/rws_interface.h
+++ b/include/abb_librws/rws_interface.h
@@ -478,6 +478,16 @@ public:
    */
   std::string getLogText(const bool verbose = false);
 
+  /**
+   * \brief A method for setting the HTTP communication timeout.
+   *
+   * \param timeout for the HTTP communication timeout [microseconds].
+   */
+  void setHTTPTimeout(const Poco::Int64 timeout)
+  {
+    rws_client_.setHTTPTimeout(timeout);
+  }
+
 protected:
   /**
    * \brief A method for comparing a single text content (from a XML document node) with a specific string value.

--- a/include/abb_librws/rws_poco_client.h
+++ b/include/abb_librws/rws_poco_client.h
@@ -404,7 +404,7 @@ private:
   /**
    * \brief Static constant for the default HTTP communication timeout [microseconds].
    */
-  static const Poco::Int64 DEFAULT_HTTP_TIMEOUT = 400000;
+  static const Poco::Int64 DEFAULT_HTTP_TIMEOUT = 400e3;
 
   /**
    * \brief Static constant for the socket's buffer size.

--- a/include/abb_librws/rws_poco_client.h
+++ b/include/abb_librws/rws_poco_client.h
@@ -308,7 +308,9 @@ public:
   /**
    * \brief A method for setting the HTTP communication timeout.
    *
-   * \note This method resets the internal HTTP client session.
+   * \note This method resets the internal HTTP client session, causing the
+   *       RWS server (robot controller) to send a new cookie. The RWS
+   *       session id is not changed.
    *
    * \param timeout for the HTTP communication timeout [microseconds].
    */

--- a/include/abb_librws/rws_poco_client.h
+++ b/include/abb_librws/rws_poco_client.h
@@ -328,10 +328,11 @@ public:
    *
    * \param uri for the URI (path and query).
    * \param protocol for the WebSocket protocol.
+   * \param timeout for the WebSocket communication timeout [microseconds].
    *
    * \return POCOResult containing the result.
    */
-  POCOResult webSocketConnect(const std::string uri, const std::string protocol);
+  POCOResult webSocketConnect(const std::string uri, const std::string protocol, const Poco::Int64 timeout);
   
   /**
    * \brief A method for receiving a WebSocket frame.

--- a/include/abb_librws/rws_poco_client.h
+++ b/include/abb_librws/rws_poco_client.h
@@ -259,7 +259,7 @@ public:
   http_credentials_(username, password)
   {
     http_client_session_.setKeepAlive(true);
-    http_client_session_.setTimeout(Poco::Timespan(DEFAULT_TIMEOUT));
+    http_client_session_.setTimeout(Poco::Timespan(DEFAULT_HTTP_TIMEOUT));
   }
 
   /**
@@ -306,14 +306,15 @@ public:
   POCOResult httpDelete(const std::string uri);
   
   /**
-   * \brief A method for resetting the timeout to the default value.
+   * \brief A method for setting the HTTP communication timeout.
+   *
+   * \param timeout for the HTTP communication timeout [microseconds].
    */
-  void resetTimeout() { http_client_session_.setTimeout(Poco::Timespan(DEFAULT_TIMEOUT)); }
-  
-  /**
-   * \brief A method for setting the timeout to a long value.
-   */
-  void setLongTimeout() { http_client_session_.setTimeout(Poco::Timespan(LONG_TIMEOUT)); }
+  void setHTTPTimeout(const Poco::Int64 timeout)
+  {
+    http_client_session_.setTimeout(Poco::Timespan(timeout));                              
+    http_client_session_.reset();
+  }
 
   /**
    * \brief A method for checking if the WebSocket exist.
@@ -400,14 +401,9 @@ private:
   void extractAndStoreCookie(const std::string cookie_string);
 
   /**
-   * \brief Static constant for the default timeout for HTTP requests, in microseconds.
+   * \brief Static constant for the default HTTP communication timeout [microseconds].
    */
-  static const Poco::Int64 DEFAULT_TIMEOUT = 400000;
-  
-  /**
-   * \brief Static constant for a long timeout for HTTP requests, in microseconds.
-   */
-  static const Poco::Int64 LONG_TIMEOUT = 10000000;
+  static const Poco::Int64 DEFAULT_HTTP_TIMEOUT = 400000;
 
   /**
    * \brief Static constant for the socket's buffer size.

--- a/include/abb_librws/rws_poco_client.h
+++ b/include/abb_librws/rws_poco_client.h
@@ -308,13 +308,13 @@ public:
   /**
    * \brief A method for setting the HTTP communication timeout.
    *
+   * \note This method resets the internal HTTP client session.
+   *
    * \param timeout for the HTTP communication timeout [microseconds].
    */
   void setHTTPTimeout(const Poco::Int64 timeout)
   {
     http_client_session_.setTimeout(Poco::Timespan(timeout));
-
-    // Note: The new timeout does not seem to be applied without a reset.                     
     http_client_session_.reset();
   }
 

--- a/include/abb_librws/rws_poco_client.h
+++ b/include/abb_librws/rws_poco_client.h
@@ -312,7 +312,9 @@ public:
    */
   void setHTTPTimeout(const Poco::Int64 timeout)
   {
-    http_client_session_.setTimeout(Poco::Timespan(timeout));                              
+    http_client_session_.setTimeout(Poco::Timespan(timeout));
+
+    // Note: The new timeout does not seem to be applied without a reset.                     
     http_client_session_.reset();
   }
 

--- a/src/rws_client.cpp
+++ b/src/rws_client.cpp
@@ -425,7 +425,8 @@ RWSClient::RWSResult RWSClient::startSubscription(SubscriptionResources resource
       evaluation_conditions_.reset();
       evaluation_conditions_.parse_message_into_xml = false;
       evaluation_conditions_.accepted_outcomes.push_back(HTTPResponse::HTTP_SWITCHING_PROTOCOLS);
-      result = evaluatePOCOResult(webSocketConnect(poll, "robapi2_subscription"), evaluation_conditions_);
+      result = evaluatePOCOResult(webSocketConnect(poll, "robapi2_subscription", DEFAULT_SUBSCRIPTION_TIMEOUT),
+                                  evaluation_conditions_);
 
       if(!result.success)
       {

--- a/src/rws_poco_client.cpp
+++ b/src/rws_poco_client.cpp
@@ -314,7 +314,9 @@ POCOClient::POCOResult POCOClient::makeHTTPRequest(const std::string method,
   return result;
 }
 
-POCOClient::POCOResult POCOClient::webSocketConnect(const std::string uri, const std::string protocol)
+POCOClient::POCOResult POCOClient::webSocketConnect(const std::string uri,
+                                                    const std::string protocol,
+                                                    const Poco::Int64 timeout)
 {
   // Lock the object's mutex. It is released when the method goes out of scope.
   ScopedLock<Mutex> lock(http_mutex_);
@@ -333,7 +335,7 @@ POCOClient::POCOResult POCOClient::webSocketConnect(const std::string uri, const
   {
     result.addHTTPRequestInfo(request);
     p_websocket_ = new WebSocket(http_client_session_, request, response);
-    p_websocket_->setReceiveTimeout(Poco::Timespan(LONG_TIMEOUT));
+    p_websocket_->setReceiveTimeout(Poco::Timespan(timeout));
       
     result.addHTTPResponseInfo(response);
     result.status = POCOResult::OK;


### PR DESCRIPTION
Updated implementation for setting HTTP and WebSocket communication timeouts.

Solves  https://github.com/ros-industrial/abb_librws/issues/28 and https://github.com/ros-industrial/abb_librws/issues/39
