### PR TITLE
Add thread-safe way to interrupt waitForSubscriptionEvent().

### DIFF
--- a/include/abb_librws/rws_client.h
+++ b/include/abb_librws/rws_client.h
@@ -574,6 +574,16 @@ public:
    * \return RWSResult containing the result.
    */
   RWSResult endSubscription();
+
+  /**
+   * \brief Close the active subscription connection.
+   *
+   * This will cause waitForSubscriptionEvent() to return or throw.
+   * It does not delete the subscription from the controller.
+   *
+   * This function blocks until an active waitForSubscriptionEvent() has finished.
+   */
+  void closeSubscription();
   
   /**
    * \brief A method for logging out the currently active RWS session.

--- a/include/abb_librws/rws_client.h
+++ b/include/abb_librws/rws_client.h
@@ -576,14 +576,19 @@ public:
   RWSResult endSubscription();
 
   /**
-   * \brief Close the active subscription connection.
+   * \brief Force close the active subscription connection.
    *
    * This will cause waitForSubscriptionEvent() to return or throw.
    * It does not delete the subscription from the controller.
    *
+   * The preferred way to close the subscription is to request the robot controller to end it via
+   * endSubscription(). This function can be used to force the connection to close immediately in
+   * case the robot controller is not responding.
+   *
    * This function blocks until an active waitForSubscriptionEvent() has finished.
+   *
    */
-  void closeSubscription();
+  void forceCloseSubscription();
   
   /**
    * \brief A method for logging out the currently active RWS session.

--- a/include/abb_librws/rws_interface.h
+++ b/include/abb_librws/rws_interface.h
@@ -513,14 +513,18 @@ public:
   bool endSubscription();
 
   /**
-   * \brief Close the active subscription connection.
+   * \brief Froce close the active subscription connection.
    *
    * This will cause waitForSubscriptionEvent() to return or throw.
    * It does not delete the subscription from the controller.
    *
+   * The preferred way to close the subscription is to request the robot controller to end it via
+   * endSubscription(). This function can be used to force the connection to close immediately in
+   * case the robot controller is not responding.
+   *
    * This function blocks until an active waitForSubscriptionEvent() has finished.
    */
-  void closeSubscription();
+  void forceCloseSubscription();
 
   /**
    * \brief A method for registering a user as local.

--- a/include/abb_librws/rws_interface.h
+++ b/include/abb_librws/rws_interface.h
@@ -513,6 +513,16 @@ public:
   bool endSubscription();
 
   /**
+   * \brief Close the active subscription connection.
+   *
+   * This will cause waitForSubscriptionEvent() to return or throw.
+   * It does not delete the subscription from the controller.
+   *
+   * This function blocks until an active waitForSubscriptionEvent() has finished.
+   */
+  void closeSubscription();
+
+  /**
    * \brief A method for registering a user as local.
    *
    * \param username specifying the user name.

--- a/include/abb_librws/rws_poco_client.h
+++ b/include/abb_librws/rws_poco_client.h
@@ -346,6 +346,19 @@ public:
   POCOResult webSocketRecieveFrame();
 
   /**
+   * \brief Close the websocket connection.
+   *
+   * The connection is closed immediately.
+   * Subsequently, the function will block until a current call to webSocketRecieveFrame() has finished,
+   * before cleaning up the local state.
+   *
+   * Note that since mutexes do not guarantee the order of acquisition for multiple contenders,
+   * it is undefined how many calls to webSocketRecieveFrame() will still attempt to use the closed
+   * connection before the local state is cleaned. Those invocation will raise a runtime error.
+   */
+  void webSocketClose();
+
+  /**
    * \brief A method for retrieving a substring in a string.
    *
    * \param whole_string for the string containing the substring.
@@ -421,9 +434,27 @@ private:
   Poco::Mutex http_mutex_;
 
   /**
-   * \brief A mutex for protecting the client's WebSocket resources.
+   * \brief A mutex for protecting the client's WebSocket pointer.
+   *
+   * This mutex must be held while setting or invalidating the p_websocket_ member.
+   * Note that the websocket_use_mutex_ must also be held while invalidating the pointer,
+   * since someone may be using it otherwise.
+   *
+   * If acquiring both websocket_connect_mutex_ and websocket_use_mutex_,
+   * the connect mutex must be acquired first.
    */
-  Poco::Mutex websocket_mutex_;
+  Poco::Mutex websocket_connect_mutex_;
+
+  /**
+   * \brief A mutex for protecting the client's WebSocket resources.
+   *
+   * This mutex must be held while using the p_websocket_ member,
+   * and while invalidating the pointer.
+   *
+   * If acquiring both websocket_connect_mutex_ and websocket_use_mutex_,
+   * the connect mutex must be acquired first.
+   */
+  Poco::Mutex websocket_use_mutex_;
 
   /**
    * \brief HTTP credentials for the remote server's access authentication process.

--- a/include/abb_librws/rws_poco_client.h
+++ b/include/abb_librws/rws_poco_client.h
@@ -346,17 +346,17 @@ public:
   POCOResult webSocketRecieveFrame();
 
   /**
-   * \brief Close the websocket connection.
+   * \brief Forcibly shut down the websocket connection.
    *
-   * The connection is closed immediately.
+   * The connection is shut down immediately.
    * Subsequently, the function will block until a current call to webSocketRecieveFrame() has finished,
    * before cleaning up the local state.
    *
    * Note that since mutexes do not guarantee the order of acquisition for multiple contenders,
-   * it is undefined how many calls to webSocketRecieveFrame() will still attempt to use the closed
-   * connection before the local state is cleaned. Those invocation will raise a runtime error.
+   * it is undefined how many calls to webSocketRecieveFrame() will still attempt to use the shut down
+   * connection before the local state is cleaned. Those invocation will throw a runtime error.
    */
-  void webSocketClose();
+  void webSocketShutdown();
 
   /**
    * \brief A method for retrieving a substring in a string.

--- a/src/rws_client.cpp
+++ b/src/rws_client.cpp
@@ -490,6 +490,10 @@ RWSClient::RWSResult RWSClient::endSubscription()
   return result;
 }
 
+void RWSClient::closeSubscription() {
+  webSocketClose();
+}
+
 RWSClient::RWSResult RWSClient::logout()
 {
   uri_ = Resources::LOGOUT;

--- a/src/rws_client.cpp
+++ b/src/rws_client.cpp
@@ -490,8 +490,9 @@ RWSClient::RWSResult RWSClient::endSubscription()
   return result;
 }
 
-void RWSClient::closeSubscription() {
-  webSocketClose();
+void RWSClient::forceCloseSubscription()
+{
+  webSocketShutdown();
 }
 
 RWSClient::RWSResult RWSClient::logout()

--- a/src/rws_interface.cpp
+++ b/src/rws_interface.cpp
@@ -374,6 +374,10 @@ bool RWSInterface::endSubscription()
   return rws_client_.endSubscription().success;
 }
 
+void RWSInterface::closeSubscription() {
+  rws_client_.webSocketClose();
+}
+
 bool RWSInterface::registerLocalUser(std::string username,
                                      std::string application,
                                      std::string location)

--- a/src/rws_interface.cpp
+++ b/src/rws_interface.cpp
@@ -374,8 +374,9 @@ bool RWSInterface::endSubscription()
   return rws_client_.endSubscription().success;
 }
 
-void RWSInterface::closeSubscription() {
-  rws_client_.webSocketClose();
+void RWSInterface::forceCloseSubscription()
+{
+  rws_client_.webSocketShutdown();
 }
 
 bool RWSInterface::registerLocalUser(std::string username,

--- a/src/rws_poco_client.cpp
+++ b/src/rws_poco_client.cpp
@@ -335,13 +335,16 @@ POCOClient::POCOResult POCOClient::webSocketConnect(const std::string uri,
   {
     result.addHTTPRequestInfo(request);
     {
-      // We must have atleast websocket_connect_mutext_,
+      // We must have at least websocket_connect_mutext_,
       // but if a connection already exists, we must also have websocket_use_mutex_.
       ScopedLock<Mutex> connect_lock(websocket_connect_mutex_);
-      if (webSocketExist()) {
+      if (webSocketExist())
+      {
         ScopedLock<Mutex> use_lock(websocket_use_mutex_);
         p_websocket_ = new WebSocket(http_client_session_, request, response);
-      } else {
+      }
+      else
+      {
         p_websocket_ = new WebSocket(http_client_session_, request, response);
       }
 
@@ -462,12 +465,14 @@ POCOClient::POCOResult POCOClient::webSocketRecieveFrame()
   return result;
 }
 
-void POCOClient::webSocketClose() {
+void POCOClient::webSocketShutdown()
+{
   // Make sure nobody is connecting while we're closing.
   ScopedLock<Mutex> connect_lock(websocket_connect_mutex_);
 
   // Make sure there is actually a connection to close.
-  if (!webSocketExist()) {
+  if (!webSocketExist())
+  {
     return;
   }
 

--- a/src/rws_poco_client.cpp
+++ b/src/rws_poco_client.cpp
@@ -471,8 +471,8 @@ void POCOClient::webSocketClose() {
     return;
   }
 
-  // Close the socket. This should make webSocketReceiveFrame() return asap.
-  p_websocket_->close();
+  // Shut down the socket. This should make webSocketReceiveFrame() return as soon as possible.
+  p_websocket_->shutdown();
 
   // Also acquire the websocket lock before invalidating the pointer,
   // or we will break running calls to webSocketRecieveFrame().

--- a/src/rws_poco_client.cpp
+++ b/src/rws_poco_client.cpp
@@ -335,18 +335,12 @@ POCOClient::POCOResult POCOClient::webSocketConnect(const std::string uri,
   {
     result.addHTTPRequestInfo(request);
     {
-      // We must have at least websocket_connect_mutext_,
-      // but if a connection already exists, we must also have websocket_use_mutex_.
+      // We must have at least websocket_connect_mutext_.
+      // If a connection already exists, we must also have websocket_use_mutex_.
+      // If not, nobody should have the mutex anyway, so we should get it immediately.
       ScopedLock<Mutex> connect_lock(websocket_connect_mutex_);
-      if (webSocketExist())
-      {
-        ScopedLock<Mutex> use_lock(websocket_use_mutex_);
-        p_websocket_ = new WebSocket(http_client_session_, request, response);
-      }
-      else
-      {
-        p_websocket_ = new WebSocket(http_client_session_, request, response);
-      }
+      ScopedLock<Mutex> use_lock(websocket_use_mutex_);
+      p_websocket_ = new WebSocket(http_client_session_, request, response);
 
       p_websocket_->setReceiveTimeout(Poco::Timespan(timeout));
     }


### PR DESCRIPTION
This is an attempt to solve #59. It closes the socket in order to interrupt `p_websocket_->receiveFrame()`, and in turn `waitForSubscriptionEvent()`.

A separate mutex is now used for setting `p_websocket_` and for using it. I believe this way there is no unnecessary blocking, but also no unsafe invalidation of `p_websocket_`.

From my understanding, closing the socket before a full frame has been received will make `receiveFrame()` throw a `WebSocketException`, which seems fine to me.