### PR TITLE
Add RWSClient::getIOSignals().

### DIFF
--- a/include/abb_librws/rws_client.h
+++ b/include/abb_librws/rws_client.h
@@ -358,6 +358,13 @@ public:
   RWSResult getConfigurationInstances(const std::string topic, const std::string type);
 
   /**
+   * \brief A method for retrieving all available IO signals on the controller.
+   *
+   * \return RWSResult containing the result.
+   */
+  RWSResult getIOSignals();
+
+  /**
    * \brief A method for retrieving the value of an IO signal.
    * 
    * \param iosignal for the IO signal's name.

--- a/src/rws_client.cpp
+++ b/src/rws_client.cpp
@@ -113,6 +113,17 @@ RWSClient::RWSResult RWSClient::getConfigurationInstances(const std::string topi
   return evaluatePOCOResult(httpGet(uri_), evaluation_conditions_);
 }
 
+RWSClient::RWSResult RWSClient::getIOSignals()
+{
+  std::string const & uri = SystemConstants::RWS::Resources::RW_IOSYSTEM_SIGNALS;
+
+  evaluation_conditions_.reset();
+  evaluation_conditions_.parse_message_into_xml = true;
+  evaluation_conditions_.accepted_outcomes.push_back(HTTPResponse::HTTP_OK);
+
+  return evaluatePOCOResult(httpGet(uri), evaluation_conditions_);
+}
+
 RWSClient::RWSResult RWSClient::getIOSignal(const std::string iosignal)
 {
   uri_ = generateIOSignalPath(iosignal);


### PR DESCRIPTION
Getting a list of all signals is very useful if you're still getting to know the robot. I wanted this functionality for a ROS wrapper we've made at RoboHouse [1]. For now, it needs a forked `abb_librws` with this patch applied.

I was kinda waiting for the other PRs to be merged first, but I suppose I might as well make make this one already.

[1] https://gitlab.com/robohouse/abb_io