### PR TITLE
Get robtarget relative to specified frames

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(abb_librws)
 
-add_compile_options(-std=c++11)
-
 find_package(catkin REQUIRED COMPONENTS cmake_modules)
 
 ########################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(abb_librws)
 
+add_compile_options(-std=c++11)
+
 find_package(catkin REQUIRED COMPONENTS cmake_modules)
 
 ########################

--- a/include/abb_librws/rws_client.h
+++ b/include/abb_librws/rws_client.h
@@ -279,6 +279,18 @@ public:
   };
 
   /**
+   * \brief An enumeration of controller coordinate frames.
+   */
+  enum class Coordinate
+  {
+    BASE,
+    WORLD,
+    TOOL,
+    WOBJ,
+    ACTIVE
+  };
+
+  /**
    * \brief A constructor.
    *
    * \param ip_address specifying the robot controller's IP address.
@@ -386,13 +398,16 @@ public:
    * \brief A method for retrieving the current robtarget values of a mechanical unit.
    *
    * \param mechunit for the mechanical unit's name.
-   * \param tool for the tool frame relative to which the robtarget will be reported
-   * \param wobj for the wobj relative to which the robtarget will be reported
-   * \param coordinate for the coordinate mode in which the robtarget will be reported
+   * \param tool for the tool frame relative to which the robtarget will be reported.
+   * \param wobj for the wobj relative to which the robtarget will be reported.
+   * \param coordinate for the coordinate mode (base, world, tool, or wobj) in which the robtarget will be reported.
    *
    * \return RWSResult containing the result.
    */
-  RWSResult getMechanicalUnitRobTarget(const std::string& mechunit, const std::string& tool = "", const std::string& wobj = "", const std::string& coordinate = "");
+  RWSResult getMechanicalUnitRobTarget(const std::string& mechunit,
+                                       const Coordinate& coordinate = RWSClient::Coordinate::ACTIVE,
+                                       const std::string& tool = "",
+                                       const std::string& wobj = "");
 
   /**
    * \brief A method for retrieving the data of a RAPID symbol.

--- a/include/abb_librws/rws_client.h
+++ b/include/abb_librws/rws_client.h
@@ -286,7 +286,7 @@ public:
     BASE,  ///< \brief Base frame coordinate
     WORLD,  ///< \brief World frame coordinate
     TOOL,  ///< \brief Tool frame coordinate
-    WOBJ,  ///< \brief Wobj frame coordinate
+    WOBJ,  ///< \brief Work object (wobj) frame coordinate
     ACTIVE  ///< \brief Currently active coordinate
   };
 
@@ -400,7 +400,7 @@ public:
    * \param mechunit for the mechanical unit's name.
    * \param coordinate for the coordinate mode (base, world, tool, or wobj) in which the robtarget will be reported.
    * \param tool for the tool frame relative to which the robtarget will be reported.
-   * \param wobj for the wobj relative to which the robtarget will be reported.
+   * \param wobj for the work object (wobj) relative to which the robtarget will be reported.
    *
    * \return RWSResult containing the result.
    */

--- a/include/abb_librws/rws_client.h
+++ b/include/abb_librws/rws_client.h
@@ -281,13 +281,13 @@ public:
   /**
    * \brief An enumeration of controller coordinate frames.
    */
-  enum class Coordinate
+  enum Coordinate
   {
-    BASE,
-    WORLD,
-    TOOL,
-    WOBJ,
-    ACTIVE
+    BASE,  ///< \brief Base frame coordinate
+    WORLD,  ///< \brief World frame coordinate
+    TOOL,  ///< \brief Tool frame coordinate
+    WOBJ,  ///< \brief Wobj frame coordinate
+    ACTIVE  ///< \brief Currently active coordinate
   };
 
   /**
@@ -398,14 +398,14 @@ public:
    * \brief A method for retrieving the current robtarget values of a mechanical unit.
    *
    * \param mechunit for the mechanical unit's name.
+   * \param coordinate for the coordinate mode (base, world, tool, or wobj) in which the robtarget will be reported.
    * \param tool for the tool frame relative to which the robtarget will be reported.
    * \param wobj for the wobj relative to which the robtarget will be reported.
-   * \param coordinate for the coordinate mode (base, world, tool, or wobj) in which the robtarget will be reported.
    *
    * \return RWSResult containing the result.
    */
   RWSResult getMechanicalUnitRobTarget(const std::string& mechunit,
-                                       const Coordinate& coordinate = RWSClient::Coordinate::ACTIVE,
+                                       const Coordinate& coordinate = ACTIVE,
                                        const std::string& tool = "",
                                        const std::string& wobj = "");
 

--- a/include/abb_librws/rws_client.h
+++ b/include/abb_librws/rws_client.h
@@ -386,10 +386,13 @@ public:
    * \brief A method for retrieving the current robtarget values of a mechanical unit.
    *
    * \param mechunit for the mechanical unit's name.
+   * \param tool for the tool frame relative to which the robtarget will be reported
+   * \param wobj for the wobj relative to which the robtarget will be reported
+   * \param coordinate for the coordinate mode in which the robtarget will be reported
    *
    * \return RWSResult containing the result.
    */
-  RWSResult getMechanicalUnitRobTarget(const std::string& mechunit);
+  RWSResult getMechanicalUnitRobTarget(const std::string& mechunit, const std::string& tool = "", const std::string& wobj = "", const std::string& coordinate = "");
 
   /**
    * \brief A method for retrieving the data of a RAPID symbol.

--- a/include/abb_librws/rws_common.h
+++ b/include/abb_librws/rws_common.h
@@ -217,6 +217,26 @@ struct SystemConstants
      * \brief Remote user.
      */
     static const std::string REMOTE;
+
+    /**
+     * \brief Base coordinate system.
+     */
+    static const std::string COORDINATE_BASE;
+
+    /**
+     * \brief World coordinate system.
+     */
+    static const std::string COORDINATE_WORLD;
+
+    /**
+     * \brief Tool coordinate system.
+     */
+    static const std::string COORDINATE_TOOL;
+
+    /**
+     * \brief Wobj coordinate system.
+     */
+    static const std::string COORDINATE_WOBJ;
   };
 
   /**

--- a/include/abb_librws/rws_common.h
+++ b/include/abb_librws/rws_common.h
@@ -234,7 +234,7 @@ struct SystemConstants
     static const std::string COORDINATE_TOOL;
 
     /**
-     * \brief Wobj coordinate system.
+     * \brief Work object (wobj) coordinate system.
      */
     static const std::string COORDINATE_WOBJ;
   };

--- a/include/abb_librws/rws_interface.h
+++ b/include/abb_librws/rws_interface.h
@@ -304,7 +304,7 @@ public:
    * \param p_robtarget for storing the retrieved robtarget data.
    * \param coordinate for the coordinate mode (base, world, tool, or wobj) in which the robtarget will be reported.
    * \param tool for the tool frame relative to which the robtarget will be reported.
-   * \param wobj for the wobj relative to which the robtarget will be reported.
+   * \param wobj for the work object (wobj) relative to which the robtarget will be reported.
    *
    * \return bool indicating if the communication was successful or not. Note: No checks are made for "correct parsing".
    */

--- a/include/abb_librws/rws_interface.h
+++ b/include/abb_librws/rws_interface.h
@@ -302,15 +302,15 @@ public:
    *
    * \param mechunit for the mechanical unit's name.
    * \param p_robtarget for storing the retrieved robtarget data.
+   * \param coordinate for the coordinate mode (base, world, tool, or wobj) in which the robtarget will be reported.
    * \param tool for the tool frame relative to which the robtarget will be reported.
    * \param wobj for the wobj relative to which the robtarget will be reported.
-   * \param coordinate for the coordinate mode (base, world, tool, or wobj) in which the robtarget will be reported.
    *
    * \return bool indicating if the communication was successful or not. Note: No checks are made for "correct parsing".
    */
   bool getMechanicalUnitRobTarget(const std::string& mechunit,
                                   RobTarget* p_robtarget,
-                                  const RWSClient::Coordinate& coordinate = RWSClient::Coordinate::ACTIVE,
+                                  const RWSClient::Coordinate& coordinate = RWSClient::ACTIVE,
                                   const std::string& tool = "",
                                   const std::string& wobj = "");
 

--- a/include/abb_librws/rws_interface.h
+++ b/include/abb_librws/rws_interface.h
@@ -302,11 +302,18 @@ public:
    *
    * \param mechunit for the mechanical unit's name.
    * \param p_robtarget for storing the retrieved robtarget data.
+   * \param tool for the tool frame relative to which the robtarget will be reported
+   * \param wobj for the wobj relative to which the robtarget will be reported
+   * \param coordinate for the coordinate mode in which the robtarget will be reported
    *
    * \return bool indicating if the communication was successful or not. Note: No checks are made for "correct parsing".
    */
-  bool getMechanicalUnitRobTarget(const std::string& mechunit, RobTarget* p_robtarget);
-
+  bool getMechanicalUnitRobTarget(const std::string& mechunit,
+                                  RobTarget *p_robtarget,
+                                  const std::string &tool = "",
+                                  const std::string &wobj = "",
+                                  const std::string &coordinate = "");
+  
   /**
    * \brief A method for retrieving the data of a RAPID symbol (parsed into a struct representing the RAPID data).
    *

--- a/include/abb_librws/rws_interface.h
+++ b/include/abb_librws/rws_interface.h
@@ -302,18 +302,18 @@ public:
    *
    * \param mechunit for the mechanical unit's name.
    * \param p_robtarget for storing the retrieved robtarget data.
-   * \param tool for the tool frame relative to which the robtarget will be reported
-   * \param wobj for the wobj relative to which the robtarget will be reported
-   * \param coordinate for the coordinate mode in which the robtarget will be reported
+   * \param tool for the tool frame relative to which the robtarget will be reported.
+   * \param wobj for the wobj relative to which the robtarget will be reported.
+   * \param coordinate for the coordinate mode (base, world, tool, or wobj) in which the robtarget will be reported.
    *
    * \return bool indicating if the communication was successful or not. Note: No checks are made for "correct parsing".
    */
   bool getMechanicalUnitRobTarget(const std::string& mechunit,
-                                  RobTarget *p_robtarget,
-                                  const std::string &tool = "",
-                                  const std::string &wobj = "",
-                                  const std::string &coordinate = "");
-  
+                                  RobTarget* p_robtarget,
+                                  const RWSClient::Coordinate& coordinate = RWSClient::Coordinate::ACTIVE,
+                                  const std::string& tool = "",
+                                  const std::string& wobj = "");
+
   /**
    * \brief A method for retrieving the data of a RAPID symbol (parsed into a struct representing the RAPID data).
    *

--- a/src/rws_client.cpp
+++ b/src/rws_client.cpp
@@ -147,19 +147,42 @@ RWSClient::RWSResult RWSClient::getMechanicalUnitJointTarget(const std::string& 
   return evaluatePOCOResult(httpGet(uri), evaluation_conditions);
 }
 
-RWSClient::RWSResult RWSClient::getMechanicalUnitRobTarget(const std::string &mechunit,
-                                                           const std::string &tool,
-                                                           const std::string &wobj,
-                                                           const std::string &coordinate)
+RWSClient::RWSResult RWSClient::getMechanicalUnitRobTarget(const std::string& mechunit,
+                                                           const Coordinate& coordinate,
+                                                           const std::string& tool,
+                                                           const std::string& wobj)
 {
   std::string uri = generateMechanicalUnitPath(mechunit) + Resources::ROBTARGET;
-  if (!coordinate.empty())
+
+  std::string args = "";
+  if (!tool.empty())
   {
-    uri += "?coordinate=" + coordinate;
-    if (!tool.empty())
-      uri += "&tool=" + tool;
-    if (!wobj.empty())
-      uri += "&wobj=" + wobj;
+    args += "&tool=" + tool;
+  }
+  if (!wobj.empty())
+  {
+    args += "&wobj=" + wobj;
+  }
+
+  const std::string coordinate_arg = "?coordinate=";
+  switch (coordinate)
+  {
+  case Coordinate::BASE:
+    uri += coordinate_arg + SystemConstants::General::COORDINATE_BASE + args;
+    break;
+  case Coordinate::WORLD:
+    uri += coordinate_arg + SystemConstants::General::COORDINATE_WORLD + args;
+    break;
+  case Coordinate::TOOL:
+    uri += coordinate_arg + SystemConstants::General::COORDINATE_TOOL + args;
+    break;
+  case Coordinate::WOBJ:
+    uri += coordinate_arg + SystemConstants::General::COORDINATE_WOBJ + args;
+    break;
+  default:
+    // If the "ACTIVE" enumeration is passed in (or any other non-identified value),
+    // do not add any arguments to this command
+    break;
   }
 
   EvaluationConditions evaluation_conditions;

--- a/src/rws_client.cpp
+++ b/src/rws_client.cpp
@@ -167,21 +167,21 @@ RWSClient::RWSResult RWSClient::getMechanicalUnitRobTarget(const std::string& me
   const std::string coordinate_arg = "?coordinate=";
   switch (coordinate)
   {
-  case Coordinate::BASE:
-    uri += coordinate_arg + SystemConstants::General::COORDINATE_BASE + args;
+    case BASE:
+      uri += coordinate_arg + SystemConstants::General::COORDINATE_BASE + args;
     break;
-  case Coordinate::WORLD:
-    uri += coordinate_arg + SystemConstants::General::COORDINATE_WORLD + args;
+    case WORLD:
+      uri += coordinate_arg + SystemConstants::General::COORDINATE_WORLD + args;
     break;
-  case Coordinate::TOOL:
-    uri += coordinate_arg + SystemConstants::General::COORDINATE_TOOL + args;
+    case TOOL:
+      uri += coordinate_arg + SystemConstants::General::COORDINATE_TOOL + args;
     break;
-  case Coordinate::WOBJ:
-    uri += coordinate_arg + SystemConstants::General::COORDINATE_WOBJ + args;
+    case WOBJ:
+      uri += coordinate_arg + SystemConstants::General::COORDINATE_WOBJ + args;
     break;
-  default:
-    // If the "ACTIVE" enumeration is passed in (or any other non-identified value),
-    // do not add any arguments to this command
+    default:
+      // If the "ACTIVE" enumeration is passed in (or any other non-identified value),
+      // do not add any arguments to this command
     break;
   }
 

--- a/src/rws_client.cpp
+++ b/src/rws_client.cpp
@@ -147,9 +147,20 @@ RWSClient::RWSResult RWSClient::getMechanicalUnitJointTarget(const std::string& 
   return evaluatePOCOResult(httpGet(uri), evaluation_conditions);
 }
 
-RWSClient::RWSResult RWSClient::getMechanicalUnitRobTarget(const std::string& mechunit)
+RWSClient::RWSResult RWSClient::getMechanicalUnitRobTarget(const std::string &mechunit,
+                                                           const std::string &tool,
+                                                           const std::string &wobj,
+                                                           const std::string &coordinate)
 {
   std::string uri = generateMechanicalUnitPath(mechunit) + Resources::ROBTARGET;
+  if (!coordinate.empty())
+  {
+    uri += "?coordinate=" + coordinate;
+    if (!tool.empty())
+      uri += "&tool=" + tool;
+    if (!wobj.empty())
+      uri += "&wobj=" + wobj;
+  }
 
   EvaluationConditions evaluation_conditions;
   evaluation_conditions.parse_message_into_xml = true;

--- a/src/rws_common.cpp
+++ b/src/rws_common.cpp
@@ -178,6 +178,10 @@ const std::string SystemConstants::General::MECHANICAL_UNIT_ROB_4  = "ROB_4";
 const std::string SystemConstants::General::MECHANICAL_UNIT_ROB_L  = "ROB_L";
 const std::string SystemConstants::General::MECHANICAL_UNIT_ROB_R  = "ROB_R";
 const std::string SystemConstants::General::REMOTE                 = "remote";
+const std::string SystemConstants::General::COORDINATE_BASE        = "Base";
+const std::string SystemConstants::General::COORDINATE_WORLD       = "Word";
+const std::string SystemConstants::General::COORDINATE_TOOL        = "Tool";
+const std::string SystemConstants::General::COORDINATE_WOBJ        = "Wobj";
 
 const std::string SystemConstants::IOSignals::HAND_ACTUAL_POSITION_L   = "hand_ActualPosition_L";
 const std::string SystemConstants::IOSignals::HAND_ACTUAL_POSITION_R   = "hand_ActualPosition_R";

--- a/src/rws_interface.cpp
+++ b/src/rws_interface.cpp
@@ -151,17 +151,17 @@ bool RWSInterface::getMechanicalUnitJointTarget(const std::string& mechunit, Joi
   return result;
 }
 
-bool RWSInterface::getMechanicalUnitRobTarget(const std::string &mechunit,
-                                              RobTarget *p_robtarget,
-                                              const std::string &tool,
-                                              const std::string &wobj,
-                                              const std::string &coordinate)
+bool RWSInterface::getMechanicalUnitRobTarget(const std::string& mechunit,
+                                              RobTarget* p_robtarget,
+                                              const RWSClient::Coordinate& coordinate,
+                                              const std::string& tool,
+                                              const std::string& wobj)
 {
   bool result = false;
 
   if (p_robtarget)
   {
-    RWSClient::RWSResult rws_result = rws_client_.getMechanicalUnitRobTarget(mechunit, tool, wobj, coordinate);
+    RWSClient::RWSResult rws_result = rws_client_.getMechanicalUnitRobTarget(mechunit, coordinate, tool, wobj);
     result = rws_result.success;
 
     if (result)

--- a/src/rws_interface.cpp
+++ b/src/rws_interface.cpp
@@ -151,13 +151,17 @@ bool RWSInterface::getMechanicalUnitJointTarget(const std::string& mechunit, Joi
   return result;
 }
 
-bool RWSInterface::getMechanicalUnitRobTarget(const std::string& mechunit, RobTarget* p_robtarget)
+bool RWSInterface::getMechanicalUnitRobTarget(const std::string &mechunit,
+                                              RobTarget *p_robtarget,
+                                              const std::string &tool,
+                                              const std::string &wobj,
+                                              const std::string &coordinate)
 {
   bool result = false;
 
   if (p_robtarget)
   {
-    RWSClient::RWSResult rws_result = rws_client_.getMechanicalUnitRobTarget(mechunit);
+    RWSClient::RWSResult rws_result = rws_client_.getMechanicalUnitRobTarget(mechunit, tool, wobj, coordinate);
     result = rws_result.success;
 
     if (result)


### PR DESCRIPTION
The current implementation of the `getMechanicalUnitRobTarget` function returns the `robtarget` relative to the active `wobj` and `tool` frames. This PR adds the ability to specify those frames as well as the coordinate mode when requesting `robtarget` data.