### PR TITLE
Removed reference from input argument

### DIFF
--- a/include/abb_librws/rws_rapid.h
+++ b/include/abb_librws/rws_rapid.h
@@ -321,7 +321,7 @@ protected:
    *
    * \return unsigned int containing the number of times the character occurs.
    */
-  unsigned int countCharInString(std::string& input, const char character);
+  unsigned int countCharInString(std::string input, const char character);
 
   /**
    * \brief A method to extract delimited substrings in a string.

--- a/src/rws_rapid.cpp
+++ b/src/rws_rapid.cpp
@@ -214,7 +214,7 @@ RAPIDRecord& RAPIDRecord::operator=(const RAPIDRecord& other)
  * Auxiliary methods
  */
 
-unsigned int RAPIDRecord::countCharInString(std::string& input, const char character)
+unsigned int RAPIDRecord::countCharInString(std::string input, const char character)
 {
   bool done = false;
   unsigned int count = 0;


### PR DESCRIPTION
Fix for a bug that was accidently introduced in PR #58.

The bug caused nestled RAPID records to be wrongly parsed.