### PR TITLE
Fix nested rapid records copy

### DIFF
--- a/include/abb_librws/rws_rapid.h
+++ b/include/abb_librws/rws_rapid.h
@@ -465,6 +465,25 @@ public:
   }
 
   /**
+   * \brief Copy constructor.
+   *
+   * \param other containing the values to copy.
+   */
+  JointTarget(const JointTarget& other)
+  :
+  RAPIDRecord(other.record_type_name_)
+  {
+    if (this != &other)
+    {
+      robax = other.robax;
+      extax = other.extax;
+      components_.clear();
+      components_.push_back(&robax);
+      components_.push_back(&extax);
+    }
+  }
+
+  /**
    * \brief Robot axes.
    */
   RobJoint robax;
@@ -567,6 +586,25 @@ public:
   }
 
   /**
+   * \brief Copy constructor.
+   *
+   * \param other containing the values to copy.
+   */
+  Pose(const Pose& other)
+  :
+  RAPIDRecord(other.record_type_name_)
+  {
+    if (this != &other)
+    {
+      pos = other.pos;
+      rot = other.rot;
+      components_.clear();
+      components_.push_back(&pos);
+      components_.push_back(&rot);
+    }
+  }
+
+  /**
    * \brief Position (x, y, z) [mm].
    */
   Pos pos;
@@ -637,6 +675,29 @@ public:
   }
 
   /**
+   * \brief Copy constructor.
+   *
+   * \param other containing the values to copy.
+   */
+  RobTarget(const RobTarget& other)
+  :
+  RAPIDRecord(other.record_type_name_)
+  {
+    if (this != &other)
+    {
+      pos = other.pos;
+      orient = other.orient;
+      robconf = other.robconf;
+      extax = other.extax;
+      components_.clear();
+      components_.push_back(&pos);
+      components_.push_back(&orient);
+      components_.push_back(&robconf);
+      components_.push_back(&extax);
+    }
+  }
+
+  /**
    * \brief Position for the tool center point [mm].
    */
   Pos pos;
@@ -676,6 +737,33 @@ public:
     components_.push_back(&ix);
     components_.push_back(&iy);
     components_.push_back(&iz);
+  }
+
+  /**
+   * \brief Copy constructor.
+   *
+   * \param other containing the values to copy.
+   */
+  LoadData(const LoadData& other)
+  :
+  RAPIDRecord(other.record_type_name_)
+  {
+    if (this != &other)
+    {
+      mass = other.mass;
+      cog = other.cog;
+      aom = other.aom;
+      ix = other.ix;
+      iy = other.iy;
+      iz = other.iz;
+      components_.clear();
+      components_.push_back(&mass);
+      components_.push_back(&cog);
+      components_.push_back(&aom);
+      components_.push_back(&ix);
+      components_.push_back(&iy);
+      components_.push_back(&iz);
+    }
   }
 
   /**
@@ -728,6 +816,27 @@ public:
   }
 
   /**
+   * \brief Copy constructor.
+   *
+   * \param other containing the values to copy.
+   */
+  ToolData(const ToolData& other)
+  :
+  RAPIDRecord(other.record_type_name_)
+  {
+    if (this != &other)
+    {
+      robhold = other.robhold;
+      tframe = other.tframe;
+      tload = other.tload;
+      components_.clear();
+      components_.push_back(&robhold);
+      components_.push_back(&tframe);
+      components_.push_back(&tload);
+    }
+  }
+
+  /**
    * \brief Defines if the robot is holding the tool or not.
    */
   RAPIDBool robhold;
@@ -761,6 +870,31 @@ public:
     components_.push_back(&ufmec);
     components_.push_back(&uframe);
     components_.push_back(&oframe);
+  }
+
+  /**
+   * \brief Copy constructor.
+   *
+   * \param other containing the values to copy.
+   */
+  WObjData(const WObjData& other)
+  :
+  RAPIDRecord(other.record_type_name_)
+  {
+    if (this != &other)
+    {
+      robhold = other.robhold;
+      ufprog = other.ufprog;
+      ufmec = other.ufmec;
+      uframe = other.uframe;
+      oframe = other.oframe;
+      components_.clear();
+      components_.push_back(&robhold);
+      components_.push_back(&ufprog);
+      components_.push_back(&ufmec);
+      components_.push_back(&uframe);
+      components_.push_back(&oframe);
+    }
   }
 
   /**

--- a/include/abb_librws/rws_state_machine_interface.h
+++ b/include/abb_librws/rws_state_machine_interface.h
@@ -413,6 +413,37 @@ public:
     };
 
     /**
+     * \brief Copy constructor.
+     *
+     * \param other containing the values to copy.
+     */
+    EGMActivateSettings(const EGMActivateSettings& other)
+    :
+    RAPIDRecord(other.record_type_name_)
+    {
+      if (this != &other)
+      {
+        tool = other.tool;
+        wobj = other.wobj;
+        correction_frame = other.correction_frame;
+        sensor_frame = other.sensor_frame;
+        cond_min_max = other.cond_min_max;
+        lp_filter = other.lp_filter;
+        sample_rate = other.sample_rate;
+        max_speed_deviation = other.max_speed_deviation;
+        components_.clear();
+        components_.push_back(&tool);
+        components_.push_back(&wobj);
+        components_.push_back(&correction_frame);
+        components_.push_back(&sensor_frame);
+        components_.push_back(&cond_min_max);
+        components_.push_back(&lp_filter);
+        components_.push_back(&sample_rate);
+        components_.push_back(&max_speed_deviation);
+      }
+    }
+
+    /**
      * \brief The tool to use.
      */
     ToolData tool;
@@ -483,6 +514,29 @@ public:
     }
 
     /**
+     * \brief Copy constructor.
+     *
+     * \param other containing the values to copy.
+     */
+    EGMRunSettings(const EGMRunSettings& other)
+    :
+    RAPIDRecord(other.record_type_name_)
+    {
+      if (this != &other)
+      {
+        cond_time = other.cond_time;
+        ramp_in_time = other.ramp_in_time;
+        offset = other.offset;
+        pos_corr_gain = other.pos_corr_gain;
+        components_.clear();
+        components_.push_back(&cond_time);
+        components_.push_back(&ramp_in_time);
+        components_.push_back(&offset);
+        components_.push_back(&pos_corr_gain);
+      }
+    }
+
+    /**
      * \brief Condition time [s].
      */
     RAPIDNum cond_time;
@@ -544,6 +598,33 @@ public:
       components_.push_back(&activate);
       components_.push_back(&run);
       components_.push_back(&stop);
+    }
+
+    /**
+     * \brief Copy constructor.
+     *
+     * \param other containing the values to copy.
+     */
+    EGMSettings(const EGMSettings& other)
+    :
+    RAPIDRecord(other.record_type_name_)
+    {
+      if (this != &other)
+      {
+        allow_egm_motions = other.allow_egm_motions;
+        use_presync = other.use_presync;
+        setup_uc = other.setup_uc;
+        activate = other.activate;
+        run = other.run;
+        stop = other.stop;
+        components_.clear();
+        components_.push_back(&allow_egm_motions);
+        components_.push_back(&use_presync);
+        components_.push_back(&setup_uc);
+        components_.push_back(&activate);
+        components_.push_back(&run);
+        components_.push_back(&stop);
+      }
     }
 
     /**


### PR DESCRIPTION
Adds copy constructors to the RAPID record representations, to be able to copy nestled instances.