### PR TITLE
Bump version to 1.2.0

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>abb_librws</name>
-  <version>1.0.0</version>
+  <version>1.2.0</version>
   <description>Package for easing the use of ABB's Robot Web Services (RWS) feature</description>
   <maintainer email="jon.tjerngren@se.abb.com">Jon Tjerngren</maintainer>
   <license>BSD 3-Clause</license>


### PR DESCRIPTION
As per subject.

We've been at `1.0.0` for quite some time now, even though changes have accumulated.

I'm not entirely sure whether the migration to plain CMake warrants a major version nr bump, but I'd be open to it.

At the very least we should increase the minor version, so as to be able to distinguish the initial release from the current state.
