### PR TITLE
Get and set of RAPID symbols in raw text format

### DIFF
--- a/include/abb_librws/rws_interface.h
+++ b/include/abb_librws/rws_interface.h
@@ -648,6 +648,21 @@ public:
   bool setIOSignal(const std::string& iosignal, const std::string& value);
 
   /**
+   * \brief A method for setting the data of a RAPID symbol via raw text format.
+   *
+   * \param task for the name of the RAPID task containing the RAPID symbol.
+   * \param module for the name of the RAPID module containing the RAPID symbol.
+   * \param name for the name of the RAPID symbol.
+   * \param data containing the RAPID symbol's new data.
+   *
+   * \return bool indicating if the communication was successful or not.
+   */
+  bool setRAPIDSymbolData(const std::string& task,
+                          const std::string& module,
+                          const std::string& name,
+                          const std::string& data);
+
+  /**
    * \brief A method for setting the data of a RAPID symbol.
    *
    * \param task for the name of the RAPID task containing the RAPID symbol.

--- a/include/abb_librws/rws_interface.h
+++ b/include/abb_librws/rws_interface.h
@@ -660,7 +660,7 @@ public:
    *
    * Notes:
    * - The absence of square brackets implies the symbol is of atomic data type.
-   * - Square brackets mean that the symbol is of record data type (composed of subcomponents).
+   * - Record data types (composed of subcomponents) are always enclosed in square brackets.
    * - The value '9E9', in the jointtarget record, mean that the joint is not in use.
    *
    * Please see the "Technical reference manual - RAPID overview"

--- a/include/abb_librws/rws_interface.h
+++ b/include/abb_librws/rws_interface.h
@@ -559,6 +559,8 @@ public:
   /**
    * \brief A method for retrieving the data of a RAPID symbol in raw text format.
    *
+   * See the corresponding "setRAPIDSymbolData(...)" method for examples of RAPID symbols in raw text format.
+   *
    * \param task for the name of the RAPID task containing the RAPID symbol.
    * \param module for the name of the RAPID module containing the RAPID symbol.
    * \param name for the name of the RAPID symbol.

--- a/include/abb_librws/rws_interface.h
+++ b/include/abb_librws/rws_interface.h
@@ -557,6 +557,17 @@ public:
                                   const std::string& wobj = "");
 
   /**
+   * \brief A method for retrieving the data of a RAPID symbol in raw text format.
+   *
+   * \param task for the name of the RAPID task containing the RAPID symbol.
+   * \param module for the name of the RAPID module containing the RAPID symbol.
+   * \param name for the name of the RAPID symbol.
+   *
+   * \return std::string containing the data. Empty if not found.
+   */
+  std::string getRAPIDSymbolData(const std::string& task, const std::string& module, const std::string& name);
+
+  /**
    * \brief A method for retrieving the data of a RAPID symbol (parsed into a struct representing the RAPID data).
    *
    * \param task for the name of the RAPID task containing the RAPID symbol.

--- a/include/abb_librws/rws_interface.h
+++ b/include/abb_librws/rws_interface.h
@@ -659,7 +659,7 @@ public:
    * - jointtarget: "[[1, -2, 3.3, -4.4, 5, 6], [9E9, 9E9, 9E9, 9E9, 9E9, 9E9]]"
    *
    * Notes:
-   * - No square brackets mean that the symbol is of atomic data type.
+   * - The absence of square brackets implies the symbol is of atomic data type.
    * - Square brackets mean that the symbol is of record data type (composed of subcomponents).
    * - The value '9E9', in the jointtarget record, mean that the joint is not in use.
    *

--- a/include/abb_librws/rws_interface.h
+++ b/include/abb_librws/rws_interface.h
@@ -561,9 +561,9 @@ public:
    *
    * See the corresponding "setRAPIDSymbolData(...)" method for examples of RAPID symbols in raw text format.
    *
-   * \param task for the name of the RAPID task containing the RAPID symbol.
-   * \param module for the name of the RAPID module containing the RAPID symbol.
-   * \param name for the name of the RAPID symbol.
+   * \param task name of the RAPID task containing the RAPID symbol.
+   * \param module name of the RAPID module containing the RAPID symbol.
+   * \param name name of the RAPID symbol.
    *
    * \return std::string containing the data. Empty if not found.
    */

--- a/include/abb_librws/rws_interface.h
+++ b/include/abb_librws/rws_interface.h
@@ -667,9 +667,9 @@ public:
    * (document ID: 3HAC050947-001, revision: K) for more information
    * about basic RAPID data types and programming.
    *
-   * \param task for the name of the RAPID task containing the RAPID symbol.
-   * \param module for the name of the RAPID module containing the RAPID symbol.
-   * \param name for the name of the RAPID symbol.
+   * \param task name of the RAPID task containing the RAPID symbol.
+   * \param module name of the RAPID module containing the RAPID symbol.
+   * \param name the name of the RAPID symbol.
    * \param data containing the RAPID symbol's new data.
    *
    * \return bool indicating if the communication was successful or not.

--- a/include/abb_librws/rws_interface.h
+++ b/include/abb_librws/rws_interface.h
@@ -650,6 +650,21 @@ public:
   /**
    * \brief A method for setting the data of a RAPID symbol via raw text format.
    *
+   * Examples of RAPID symbols in raw text format:
+   * - num: "1" or "-2.5".
+   * - bool: "TRUE" or "FALSE".
+   * - pos: "[1, -2, 3.3]".
+   * - jointtarget: "[[1, -2, 3.3, -4.4, 5, 6], [9E9, 9E9, 9E9, 9E9, 9E9, 9E9]]"
+   *
+   * Notes:
+   * - No square brackets mean that the symbol is of atomic data type.
+   * - Square brackets mean that the symbol is of record data type (composed of subcomponents).
+   * - The value '9E9', in the jointtarget record, mean that the joint is not in use.
+   *
+   * Please see the "Technical reference manual - RAPID overview"
+   * (document ID: 3HAC050947-001, revision: K) for more information
+   * about basic RAPID data types and programming.
+   *
    * \param task for the name of the RAPID task containing the RAPID symbol.
    * \param module for the name of the RAPID module containing the RAPID symbol.
    * \param name for the name of the RAPID symbol.

--- a/src/rws_interface.cpp
+++ b/src/rws_interface.cpp
@@ -781,6 +781,14 @@ bool RWSInterface::getMechanicalUnitRobTarget(const std::string& mechunit,
 bool RWSInterface::setRAPIDSymbolData(const std::string& task,
                                       const std::string& module,
                                       const std::string& name,
+                                      const std::string& data)
+{
+  return rws_client_.setRAPIDSymbolData(RWSClient::RAPIDResource(task, module, name), data).success;
+}
+
+bool RWSInterface::setRAPIDSymbolData(const std::string& task,
+                                      const std::string& module,
+                                      const std::string& name,
                                       const RAPIDSymbolDataAbstract& data)
 {
   return rws_client_.setRAPIDSymbolData(RWSClient::RAPIDResource(task, module, name), data).success;

--- a/src/rws_interface.cpp
+++ b/src/rws_interface.cpp
@@ -928,6 +928,14 @@ bool RWSInterface::setIOSignal(const std::string& iosignal, const std::string& v
   return rws_client_.setIOSignal(iosignal, value).success;
 }
 
+std::string RWSInterface::getRAPIDSymbolData(const std::string& task,
+                                             const std::string& module,
+                                             const std::string& name)
+{
+  return xmlFindTextContent(rws_client_.getRAPIDSymbolData(RWSClient::RAPIDResource(task, module, name)).p_xml_document,
+                            XMLAttributes::CLASS_VALUE);
+}
+
 bool RWSInterface::getRAPIDSymbolData(const std::string& task,
                                       const std::string& module,
                                       const std::string& name,


### PR DESCRIPTION
As per title.

Examples of RAPID symbols in raw text format:
- `num`: `1` or `-2.5`.
- `bool`: `TRUE` or `FALSE`.
- `pos`: `[1, -2, 3.3]`.
- `jointtarget`: `[[1, -2, 3.3, -4.4, 5, 6], [9E9, 9E9, 9E9, 9E9, 9E9, 9E9]]`