### PR TITLE
Add methods for getting and setting speed ratio for RAPID motions

### DIFF
--- a/include/abb_librws/rws_client.h
+++ b/include/abb_librws/rws_client.h
@@ -572,6 +572,17 @@ public:
   RWSResult setMotorsOff();
 
   /**
+   * \brief A method for setting the robot controller's speed ratio for RAPID motions (e.g. MoveJ and MoveL).
+   *
+   * Note: The ratio must be an integer [0, 100] in text format.
+   *
+   * \param ratio specifying the new ratio.
+   *
+   * \return RWSResult containing the result.
+   */
+  RWSResult setSpeedRatio(const std::string& ratio);
+
+  /**
    * \brief A method for retrieving a file from the robot controller.
    *
    * Note: Depending on the file, then the content can be in text or binary format.

--- a/include/abb_librws/rws_client.h
+++ b/include/abb_librws/rws_client.h
@@ -493,6 +493,13 @@ public:
   RWSResult getRobotWareSystem();
 
   /**
+   * \brief A method for retrieving the robot controller's speed ratio for RAPID motions (e.g. MoveJ and MoveL).
+   *
+   * \return RWSResult containing the result.
+   */
+  RWSResult getSpeedRatio();
+
+  /**
    * \brief A method for retrieving the controller state.
    *
    * \return RWSResult containing the result.

--- a/include/abb_librws/rws_client.h
+++ b/include/abb_librws/rws_client.h
@@ -574,13 +574,13 @@ public:
   /**
    * \brief A method for setting the robot controller's speed ratio for RAPID motions (e.g. MoveJ and MoveL).
    *
-   * Note: The ratio must be an integer [0, 100] in text format.
+   * Note: The ratio must be an integer in the range [0, 100] (ie: inclusive).
    *
    * \param ratio specifying the new ratio.
    *
    * \return RWSResult containing the result.
    */
-  RWSResult setSpeedRatio(const std::string& ratio);
+  RWSResult setSpeedRatio(unsigned int ratio);
 
   /**
    * \brief A method for retrieving a file from the robot controller.

--- a/include/abb_librws/rws_client.h
+++ b/include/abb_librws/rws_client.h
@@ -579,6 +579,9 @@ public:
    * \param ratio specifying the new ratio.
    *
    * \return RWSResult containing the result.
+   *
+   * \throw std::out_of_range if argument is out of range.
+   * \throw std::runtime_error if failed to create a string from the argument.
    */
   RWSResult setSpeedRatio(unsigned int ratio);
 

--- a/include/abb_librws/rws_interface.h
+++ b/include/abb_librws/rws_interface.h
@@ -743,6 +743,17 @@ public:
   bool setMotorsOff();
 
   /**
+   * \brief A method for setting the robot controller's speed ratio for RAPID motions (e.g. MoveJ and MoveL).
+   *
+   * Note: The ratio must be an integer [0, 100].
+   *
+   * \param ratio specifying the new ratio.
+   *
+   * \return bool indicating if the communication was successful or not.
+   */
+  bool setSpeedRatio(unsigned int ratio);
+
+  /**
    * \brief A method for retrieving a file from the robot controller.
    *
    * Note: Depending on the file, then the content can be in text or binary format.

--- a/include/abb_librws/rws_interface.h
+++ b/include/abb_librws/rws_interface.h
@@ -612,6 +612,15 @@ public:
   std::vector<RAPIDTaskInfo> getRAPIDTasks();
 
   /**
+   * \brief A method for retrieving the robot controller's speed ratio for RAPID motions (e.g. MoveJ and MoveL).
+   *
+   * \return unsigned int with the speed ratio in the range [0, 100] (ie: inclusive).
+   *
+   * \throw std::runtime_error if failed to get or parse the speed ratio.
+   */
+  unsigned int getSpeedRatio();
+
+  /**
    * \brief A method for retrieving some system information from the robot controller.
    *
    * \return SystemInfo containing the system information (info will be empty if e.g. a timeout occurred).

--- a/include/abb_librws/rws_interface.h
+++ b/include/abb_librws/rws_interface.h
@@ -745,7 +745,7 @@ public:
   /**
    * \brief A method for setting the robot controller's speed ratio for RAPID motions (e.g. MoveJ and MoveL).
    *
-   * Note: The ratio must be an integer [0, 100].
+   * Note: The ratio must be an integer in the range [0, 100] (ie: inclusive).
    *
    * \param ratio specifying the new ratio.
    *

--- a/src/rws_client.cpp
+++ b/src/rws_client.cpp
@@ -439,10 +439,18 @@ RWSClient::RWSResult RWSClient::setMotorsOff()
   return evaluatePOCOResult(httpPost(uri, content), evaluation_conditions);
 }
 
-RWSClient::RWSResult RWSClient::setSpeedRatio(const std::string& ratio)
+RWSClient::RWSResult RWSClient::setSpeedRatio(unsigned int ratio)
 {
+  if(ratio > 100)
+  {
+    ratio = 100;
+  }
+
+  std::stringstream ss;
+  ss << ratio;
+
   std::string uri = "/rw/panel/speedratio?action=setspeedratio";
-  std::string content = "speed-ratio=" + ratio;
+  std::string content = "speed-ratio=" + ss.str();
 
   EvaluationConditions evaluation_conditions;
   evaluation_conditions.parse_message_into_xml = false;

--- a/src/rws_client.cpp
+++ b/src/rws_client.cpp
@@ -275,6 +275,17 @@ RWSClient::RWSResult RWSClient::getRobotWareSystem()
   return evaluatePOCOResult(httpGet(uri), evaluation_conditions);
 }
 
+RWSClient::RWSResult RWSClient::getSpeedRatio()
+{
+  std::string uri = "/rw/panel/speedratio";
+
+  EvaluationConditions evaluation_conditions;
+  evaluation_conditions.parse_message_into_xml = true;
+  evaluation_conditions.accepted_outcomes.push_back(HTTPResponse::HTTP_OK);
+
+  return evaluatePOCOResult(httpGet(uri), evaluation_conditions);
+}
+
 RWSClient::RWSResult RWSClient::getPanelControllerState()
 {
   std::string uri = Resources::RW_PANEL_CTRLSTATE;

--- a/src/rws_client.cpp
+++ b/src/rws_client.cpp
@@ -458,7 +458,7 @@ RWSClient::RWSResult RWSClient::setMotorsOff()
 
 RWSClient::RWSResult RWSClient::setSpeedRatio(unsigned int ratio)
 {
-  if(ratio > 100) throw std::out_of_range("Speed ratio argument out of range");
+  if(ratio > 100) throw std::out_of_range("Speed ratio argument out of range (should be 0 <= ratio <= 100)");
 
   std::stringstream ss;
   ss << ratio;

--- a/src/rws_client.cpp
+++ b/src/rws_client.cpp
@@ -35,10 +35,16 @@
  */
 
 #include <sstream>
+#include <stdexcept>
 
 #include "Poco/SAX/InputSource.h"
 
 #include "abb_librws/rws_client.h"
+
+namespace
+{
+static const char EXCEPTION_CREATE_STRING[]{"Failed to create string"};
+}
 
 namespace abb
 {
@@ -441,13 +447,11 @@ RWSClient::RWSResult RWSClient::setMotorsOff()
 
 RWSClient::RWSResult RWSClient::setSpeedRatio(unsigned int ratio)
 {
-  if(ratio > 100)
-  {
-    ratio = 100;
-  }
+  if(ratio > 100) throw std::out_of_range("Speed ratio argument out of range");
 
   std::stringstream ss;
   ss << ratio;
+  if(ss.fail()) throw std::runtime_error(EXCEPTION_CREATE_STRING);
 
   std::string uri = "/rw/panel/speedratio?action=setspeedratio";
   std::string content = "speed-ratio=" + ss.str();

--- a/src/rws_client.cpp
+++ b/src/rws_client.cpp
@@ -439,6 +439,18 @@ RWSClient::RWSResult RWSClient::setMotorsOff()
   return evaluatePOCOResult(httpPost(uri, content), evaluation_conditions);
 }
 
+RWSClient::RWSResult RWSClient::setSpeedRatio(const std::string& ratio)
+{
+  std::string uri = "/rw/panel/speedratio?action=setspeedratio";
+  std::string content = "speed-ratio=" + ratio;
+
+  EvaluationConditions evaluation_conditions;
+  evaluation_conditions.parse_message_into_xml = false;
+  evaluation_conditions.accepted_outcomes.push_back(HTTPResponse::HTTP_NO_CONTENT);
+
+  return evaluatePOCOResult(httpPost(uri, content), evaluation_conditions);
+}
+
 RWSClient::RWSResult RWSClient::getFile(const FileResource& resource, std::string* p_file_content)
 {
   RWSResult rws_result;

--- a/src/rws_interface.cpp
+++ b/src/rws_interface.cpp
@@ -826,6 +826,19 @@ bool RWSInterface::setMotorsOff()
   return rws_client_.setMotorsOff().success;
 }
 
+bool RWSInterface::setSpeedRatio(unsigned int ratio)
+{
+  if(ratio > 100)
+  {
+    ratio = 100;
+  }
+
+  std::stringstream ss;
+  ss << ratio;
+
+  return rws_client_.setSpeedRatio(ss.str()).success;
+}
+
 std::vector<RWSInterface::RAPIDModuleInfo> RWSInterface::getRAPIDModulesInfo(const std::string& task)
 {
   std::vector<RAPIDModuleInfo> result;

--- a/src/rws_interface.cpp
+++ b/src/rws_interface.cpp
@@ -890,6 +890,20 @@ std::vector<RWSInterface::RAPIDTaskInfo> RWSInterface::getRAPIDTasks()
   return result;
 }
 
+unsigned int RWSInterface::getSpeedRatio()
+{
+  unsigned int speed_ratio = 0;
+
+  RWSClient::RWSResult rws_result = rws_client_.getSpeedRatio();
+  if(!rws_result.success) throw std::runtime_error("Failed to get the speed ratio");
+
+  std::stringstream ss(xmlFindTextContent(rws_result.p_xml_document, XMLAttribute(Identifiers::CLASS, "speedratio")));
+  ss >> speed_ratio;
+  if(ss.fail()) throw std::runtime_error("Failed to parse the speed ratio");
+
+  return speed_ratio;
+}
+
 RWSInterface::SystemInfo RWSInterface::getSystemInfo()
 {
   SystemInfo result;

--- a/src/rws_interface.cpp
+++ b/src/rws_interface.cpp
@@ -828,15 +828,7 @@ bool RWSInterface::setMotorsOff()
 
 bool RWSInterface::setSpeedRatio(unsigned int ratio)
 {
-  if(ratio > 100)
-  {
-    ratio = 100;
-  }
-
-  std::stringstream ss;
-  ss << ratio;
-
-  return rws_client_.setSpeedRatio(ss.str()).success;
+  return rws_client_.setSpeedRatio(ratio).success;
 }
 
 std::vector<RWSInterface::RAPIDModuleInfo> RWSInterface::getRAPIDModulesInfo(const std::string& task)


### PR DESCRIPTION
As per title.

Enables setting the speed ratio (in the range `[0, 100]`) for RAPID motion commands like `MoveAbsJ` and `MoveL`.

Side note: It would be nicer to use `std::to_string(...)` in [setSpeedRatio(...)](https://github.com/ros-industrial/abb_librws/compare/ros-industrial:e9003df...jontje:5b4a8b7#diff-701777f95fc9b5eff478979c076fa896e78fd32469bac23d21b51772e64b2b5bR821) when/if moving over to `C++11` standard.