### PR TITLE
Expose start and stop of EGM streaming via the StateMachine Add-In

### DIFF
--- a/include/abb_librws/rws_state_machine_interface.h
+++ b/include/abb_librws/rws_state_machine_interface.h
@@ -924,6 +924,13 @@ private:
       bool signalEGMStartPose() const;
 
       /**
+       * \brief Signal the StateMachine AddIn to start EGM position streaming.
+       *
+       * \return bool indicating if the signaling was successful or not.
+       */
+      bool signalEGMStartStream() const;
+
+      /**
        * \brief Signal the StateMachine AddIn to stop any current EGM motions.
        *
        * \return bool indicating if the signaling was successful or not.

--- a/include/abb_librws/rws_state_machine_interface.h
+++ b/include/abb_librws/rws_state_machine_interface.h
@@ -137,11 +137,25 @@ public:
       static const std::string EGM_START_POSE;
 
       /**
+       * \brief IO signal for requesting start of EGM position streaming (i.e. only feedback).
+       *
+       * Note: Requires that the EGM option exists in the controller system.
+       */
+      static const std::string EGM_START_STREAM;
+
+      /**
        * \brief IO signal for requesting stop of EGM motions.
        *
        * Note: Requires that the EGM option exists in the controller system.
        */
       static const std::string EGM_STOP;
+
+      /**
+       * \brief IO signal for requesting stop of EGM position streaming.
+       *
+       * Note: Requires that the EGM option exists in the controller system.
+       */
+      static const std::string EGM_STOP_STREAM;
 
       /**
        * \brief Prefix for IO signals, used for checking if a mechanical unit is stationary or not.

--- a/include/abb_librws/rws_state_machine_interface.h
+++ b/include/abb_librws/rws_state_machine_interface.h
@@ -937,6 +937,13 @@ private:
        */
       bool signalEGMStop() const;
 
+      /**
+       * \brief Signal the StateMachine AddIn to stop any current position streaming.
+       *
+       * \return bool indicating if the signaling was successful or not.
+       */
+      bool signalEGMStopStream() const;
+
     private:
       /**
        * \brief The RWS interface instance.

--- a/src/rws_state_machine_interface.cpp
+++ b/src/rws_state_machine_interface.cpp
@@ -171,6 +171,11 @@ bool RWSStateMachineInterface::Services::EGM::signalEGMStop() const
   return p_rws_interface_->toggleIOSignal(IOSignals::EGM_STOP);
 }
 
+bool RWSStateMachineInterface::Services::EGM::signalEGMStopStream() const
+{
+  return p_rws_interface_->toggleIOSignal(IOSignals::EGM_STOP_STREAM);
+}
+
 
 
 

--- a/src/rws_state_machine_interface.cpp
+++ b/src/rws_state_machine_interface.cpp
@@ -55,7 +55,9 @@ typedef RWSStateMachineInterface::ResourceIdentifiers::RAPID::Symbols    Symbols
 
 const std::string IOSignals::EGM_START_JOINT    = "EGM_START_JOINT";
 const std::string IOSignals::EGM_START_POSE     = "EGM_START_POSE";
+const std::string IOSignals::EGM_START_STREAM   = "EGM_START_STREAM";
 const std::string IOSignals::EGM_STOP           = "EGM_STOP";
+const std::string IOSignals::EGM_STOP_STREAM    = "EGM_STOP_STREAM";
 const std::string IOSignals::OUTPUT_STATIONARY  = "OUTPUT_STATIONARY";
 const std::string IOSignals::RUN_RAPID_ROUTINE  = "RUN_RAPID_ROUTINE";
 const std::string IOSignals::RUN_SG_ROUTINE     = "RUN_SG_ROUTINE";

--- a/src/rws_state_machine_interface.cpp
+++ b/src/rws_state_machine_interface.cpp
@@ -161,6 +161,11 @@ bool RWSStateMachineInterface::Services::EGM::signalEGMStartPose() const
   return p_rws_interface_->toggleIOSignal(IOSignals::EGM_START_POSE);
 }
 
+bool RWSStateMachineInterface::Services::EGM::signalEGMStartStream() const
+{
+  return p_rws_interface_->toggleIOSignal(IOSignals::EGM_START_STREAM);
+}
+
 bool RWSStateMachineInterface::Services::EGM::signalEGMStop() const
 {
   return p_rws_interface_->toggleIOSignal(IOSignals::EGM_STOP);


### PR DESCRIPTION
As per title.

`EGM` streaming means that `EGM` is used to only send out feedback messages, containing for example. status and current robot position. This is started and stopped via `RAPID` `EGMStreamStart` and `EGMStreamStop` commands in the `RobotWare` `StateMachine Add-In` (if the `EGM` option is present in the robot controller system).

I.e. robot motions are not controlled via `EGM`, meaning that normal `RAPID` motion commands can be used to move the robot (e.g. `MoveAbsJ` and `MoveL`) and still get high frequency feedback via `EGM`.