### PR TITLE
Update vcpkg and lukka/run-vcpkg versions

### DIFF
--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -6,7 +6,7 @@ on:
       - master
   pull_request:
   schedule:
-  # Execute a "nightly" build at 2 AM UTC
+  # Execute a "nightly" build at 2 AM UTC.
   - cron:  '0 2 * * *'
 
 jobs:
@@ -17,16 +17,16 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    # Restore from cache the previously built ports. If "cache miss"
-    # then provision vcpkg, install desired ports, finally cache everything for the next run.
+    # Restore from cache the previously built ports. If "cache miss" then provision vcpkg,
+    # install desired ports, finally cache everything for the next run.
     - name: Restore from cache and run vcpkg
       uses: lukka/run-vcpkg@v5
       with:
         vcpkgArguments: '--triplet x64-windows poco'
-        # commit corresponding to vcpkg's release v2020.11
+        # Commit corresponding to vcpkg's master branch on 2020-11-20.
         vcpkgGitCommitId: e803bf11296d8e7900dafb41e7b1224778d33dc6
-        # Workaround for https://github.com/ros-industrial/abb_libegm/pull/101#discussion_r433370614
-        # This line can be removed once Poco is linked via its imported CMake targets
+        # Workaround for https://github.com/ros-industrial/abb_libegm/pull/101#discussion_r433370614.
+        # This line can be removed once Poco is linked via its imported CMake targets.
         vcpkgDirectory: '${{ github.workspace }}/../vcpkg'
 
     - name: Configure the project

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         vcpkgArguments: '--triplet x64-windows poco'
         # commit corresponding to vcpkg's release v2020.11
-        vcpkgGitCommitId: 0bf3923f9fab4001c00f0f429682a0853b5749e0
+        vcpkgGitCommitId: e803bf11296d8e7900dafb41e7b1224778d33dc6
         # Workaround for https://github.com/ros-industrial/abb_libegm/pull/101#discussion_r433370614
         # This line can be removed once Poco is linked via its imported CMake targets
         vcpkgDirectory: '${{ github.workspace }}/../vcpkg'

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -6,7 +6,7 @@ on:
       - master
   pull_request:
   schedule:
-  # Execute a "nightly" build at 2 AM UTC 
+  # Execute a "nightly" build at 2 AM UTC
   - cron:  '0 2 * * *'
 
 jobs:
@@ -16,22 +16,22 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    
+
     # Restore from cache the previously built ports. If "cache miss"
     # then provision vcpkg, install desired ports, finally cache everything for the next run.
     - name: Restore from cache and run vcpkg
-      uses: lukka/run-vcpkg@v3
+      uses: lukka/run-vcpkg@v5
       with:
         vcpkgArguments: '--triplet x64-windows poco'
-        # commit from vcpkg's master branch on 2020/06/01
-        vcpkgGitCommitId: 6d36e2a86baf8d227fc6dce587bd69997d67fb5e
+        # commit corresponding to vcpkg's release v2020.11
+        vcpkgGitCommitId: 0bf3923f9fab4001c00f0f429682a0853b5749e0
         # Workaround for https://github.com/ros-industrial/abb_libegm/pull/101#discussion_r433370614
         # This line can be removed once Poco is linked via its imported CMake targets
-        vcpkgDirectory: '${{ github.workspace }}/../vcpkg'  
+        vcpkgDirectory: '${{ github.workspace }}/../vcpkg'
 
-    - name: Configure the project 
+    - name: Configure the project
       shell: bash
-      run: | 
+      run: |
         mkdir build
         cd build
         cmake -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake ..


### PR DESCRIPTION
The Windows `vcpkg` CI started failing two days ago ([see](https://github.com/ros-industrial/abb_librws/actions)).

See https://github.com/ros-industrial/abb_libegm/pull/113#issuecomment-729687257 for the cause.

This PR updates the `vcpkg` and `lukka/run-vcpkg` versions, similar to PR https://github.com/ros-industrial/abb_libegm/pull/114, to fix this.