### PR TITLE
Fix "Poco not found" when using an install space

### DIFF
--- a/cmake/abb_librwsConfig.cmake.in
+++ b/cmake/abb_librwsConfig.cmake.in
@@ -4,7 +4,7 @@
 
 include(CMakeFindDependencyMacro)
 
-list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 # Find dependencies
 find_dependency(Poco 1.4.3 REQUIRED COMPONENTS Foundation Net Util XML)


### PR DESCRIPTION
This fixes the install targets that end up in `share/${PROJECT_NAME}/`
Specifically:
```
share/abb_librws/package.xml
share/abb_librws/cmake/*.cmake
```
It also modifies the abb_librwsConfig.cmake, which previously specified the `CMAKE_MODULE_PATH` in relation to `${CMAKE_CURRENT_SOURCE_DIR}`.

This has been tested in a ROS kinetic (ubuntu xenial) environment with abb_librws alongside another package that depended on it. Both of them failed to build with the Poco PPA installed because the `find_package(abb_librws REQUIRED)` would fail from the generated Config.cmake file trying to find Poco.
With the applied fix, it works for both `catkin_make_isolated` and `catkin build`