### PR TITLE
Python Wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,3 +125,5 @@ install(
   FILE ${PROJECT_NAME}Targets.cmake
   NAMESPACE ${PROJECT_NAME}::
 )
+
+add_subdirectory(python)

--- a/include/abb_librws/rws_cfg.h
+++ b/include/abb_librws/rws_cfg.h
@@ -70,6 +70,19 @@ namespace moc
  */
 struct Arm
 {
+
+  /**
+   * \brief Operator for equal to comparison.
+   *
+   * \param rhs for right hand side value.
+   *
+   * \return bool indicating if the comparision was equal or not.
+   */
+  bool operator==(const Arm& rhs)
+  {
+    return name == rhs.name;
+  }
+
   /**
    * \brief The instance's name.
    */
@@ -96,6 +109,19 @@ struct Arm
  */
 struct Joint
 {
+
+  /**
+   * \brief Operator for equal to comparison.
+   *
+   * \param rhs for right hand side value.
+   *
+   * \return bool indicating if the comparision was equal or not.
+   */
+  bool operator==(const Joint& rhs)
+  {
+    return name == rhs.name;
+  }
+
   /**
    * \brief The instance's name.
    */
@@ -128,6 +154,18 @@ struct Joint
 struct MechanicalUnit
 {
   /**
+   * \brief Operator for equal to comparison.
+   *
+   * \param rhs for right hand side value.
+   *
+   * \return bool indicating if the comparision was equal or not.
+   */
+  bool operator==(const MechanicalUnit& rhs)
+  {
+    return name == rhs.name;
+  }
+
+  /**
    * \brief The instance's name.
    */
   std::string name;
@@ -148,6 +186,18 @@ struct MechanicalUnit
  */
 struct Robot
 {
+  /**
+   * \brief Operator for equal to comparison.
+   *
+   * \param rhs for right hand side value.
+   *
+   * \return bool indicating if the comparision was equal or not.
+   */
+  bool operator==(const Robot& rhs)
+  {
+    return name == rhs.name;
+  }
+
   /**
    * \brief The instance's name.
    */
@@ -180,6 +230,18 @@ struct Robot
 struct Single
 {
   /**
+   * \brief Operator for equal to comparison.
+   *
+   * \param rhs for right hand side value.
+   *
+   * \return bool indicating if the comparision was equal or not.
+   */
+  bool operator==(const Single& rhs)
+  {
+    return name == rhs.name;
+  }
+
+  /**
    * \brief The instance's name.
    */
   std::string name;
@@ -211,6 +273,18 @@ struct Single
 struct Transmission
 {
   /**
+   * \brief Operator for equal to comparison.
+   *
+   * \param rhs for right hand side value.
+   *
+   * \return bool indicating if the comparision was equal or not.
+   */
+  bool operator==(const Transmission& rhs)
+  {
+    return name == rhs.name;
+  }
+
+  /**
    * \brief The instance's name.
    */
   std::string name;
@@ -233,6 +307,18 @@ namespace sys
 struct MechanicalUnitGroup
 {
   /**
+   * \brief Operator for equal to comparison.
+   *
+   * \param rhs for right hand side value.
+   *
+   * \return bool indicating if the comparision was equal or not.
+   */
+  bool operator==(const MechanicalUnitGroup& rhs)
+  {
+    return name == rhs.name;
+  }
+
+  /**
    * \brief The instance's name.
    */
   std::string name;
@@ -253,6 +339,18 @@ struct MechanicalUnitGroup
  */
 struct PresentOption
 {
+  /**
+   * \brief Operator for equal to comparison.
+   *
+   * \param rhs for right hand side value.
+   *
+   * \return bool indicating if the comparision was equal or not.
+   */
+  bool operator==(const PresentOption& rhs)
+  {
+    return name == rhs.name;
+  }
+
   /**
    * \brief The instance's name.
    */

--- a/include/abb_librws/rws_interface.h
+++ b/include/abb_librws/rws_interface.h
@@ -242,6 +242,18 @@ public:
     {}
 
     /**
+     * \brief Operator for equal to comparison.
+     *
+     * \param rhs for right hand side value.
+     *
+     * \return bool indicating if the comparision was equal or not.
+     */
+    bool operator==(const RAPIDModuleInfo& rhs)
+    {
+      return name == rhs.name;
+    }
+
+    /**
      * \brief The module's name.
      */
     std::string name;
@@ -275,6 +287,18 @@ public:
     is_active(is_active),
     execution_state(execution_state)
     {}
+
+    /**
+     * \brief Operator for equal to comparison.
+     *
+     * \param rhs for right hand side value.
+     *
+     * \return bool indicating if the comparision was equal or not.
+     */
+    bool operator==(const RAPIDTaskInfo& rhs)
+    {
+      return name == rhs.name;
+    }
 
     /**
      * \brief The task's name.

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,0 +1,47 @@
+set(PYTHON_VERSIONS "2" "3")
+foreach(PYTHON_VERSION ${PYTHON_VERSIONS})
+  unset(PYTHON_EXECUTABLE CACHE)
+  unset(PYTHON_INCLUDE_DIR CACHE)
+  unset(PYTHON_LIBRARY CACHE)
+  unset(PYTHON_DEFAULT_EXECUTABLE CACHE)
+  find_package(PythonInterp ${PYTHON_VERSION})
+  find_package(PythonLibs ${PYTHON_VERSION})
+
+  if(PYTHON_VERSION VERSION_LESS 3)
+    find_package(Boost COMPONENTS python)
+  else()
+    find_package(Boost COMPONENTS python-py${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
+  endif()
+  if (NOT Boost_FOUND)
+    message(WARNING "Boost was not found for python ${PYTHON_VERSION}")
+    continue()
+  endif()
+
+  add_library(${PROJECT_NAME}_py${PYTHON_VERSION} rws_interface_py.cpp)
+  target_link_libraries(${PROJECT_NAME}_py${PYTHON_VERSION}
+    ${PROJECT_NAME}
+    ${Boost_LIBRARIES}
+    ${Poco_LIBRARIES}
+    ${PYTHON_LIBRARIES}
+  )
+  target_include_directories(${PROJECT_NAME}_py${PYTHON_VERSION} PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include;${CMAKE_CURRENT_BINARY_DIR}>"
+    $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>
+    ${Boost_INCLUDE_DIRS}
+    ${Poco_INCLUDE_DIRS}
+    ${PYTHON_INCLUDE_DIRS}
+  )
+  set_target_properties(${PROJECT_NAME}_py${PYTHON_VERSION}
+    PROPERTIES
+      PREFIX ""
+      OUTPUT_NAME ${PROJECT_NAME}_py
+      LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/${PROJECT_NAME}_py${PYTHON_VERSION}/)
+
+  install(TARGETS ${PROJECT_NAME}_py${PYTHON_VERSION}
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/dist-packages/${PROJECT_NAME}"
+  )
+
+  install(FILES __init__.py
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/dist-packages/${PROJECT_NAME}"
+  )
+endforeach()

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -1,0 +1,45 @@
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2020, Unibap AB (publ)
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Authors: Batu Akan, Aris Synodinos
+
+import sys, pkg_resources, imp
+
+
+def __bootstrap__():
+    global __bootstrap__, __loader__, __file__
+    filepath = '../../../python{}.{}/dist-packages/abb_librws/abb_librws_py.so'.format(sys.version_info[0], sys.version_info[1])
+    __file__ = pkg_resources.resource_filename(__name__, filepath)
+    __loader__ = None; del __bootstrap__, __loader__
+    imp.load_dynamic(__name__,__file__)
+
+__bootstrap__()

--- a/python/rws_interface_py.cpp
+++ b/python/rws_interface_py.cpp
@@ -1,0 +1,544 @@
+/***********************************************************************************************************************
+ * Software License Agreement (BSD License)
+ *
+ * Copyright (c) 2020, Unibap AB (publ)
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with
+ * or without modification, are permitted provided that
+ * the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the
+ *      above copyright notice, this list of conditions
+ *      and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the
+ *      above copyright notice, this list of conditions
+ *      and the following disclaimer in the documentation
+ *      and/or other materials provided with the
+ *      distribution.
+ *    * Neither the name of ABB nor the names of its
+ *      contributors may be used to endorse or promote
+ *      products derived from this software without
+ *      specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ***********************************************************************************************************************
+ *
+ * Authors: Batu Akan, Aris Synodinos
+ *
+ */
+
+
+#include <boost/python.hpp>
+#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
+
+#include "abb_librws/rws_interface.h"
+#include "abb_librws/rws_rapid.h"
+
+#include <Poco/DOM/DOMWriter.h>
+
+#include <vector>
+
+using namespace abb::rws;
+
+
+class PyRAPIDRecord : public RAPIDRecord
+{
+public:
+  using RAPIDRecord::RAPIDRecord;
+
+  void addComponents(RAPIDSymbolDataAbstract* data)
+  {
+    components_.push_back(data);
+  }
+};
+
+
+class RWSInterfacePy : public RWSInterface
+{
+    using RWSInterface::RWSInterface;
+    public:
+    std::string waitForSubscriptionEventAsString()
+    {
+        RWSClient::RWSResult rws_result = rws_client_.waitForSubscriptionEvent();
+        if (rws_result.success && !rws_result.p_xml_document.isNull())
+        {
+            std::ostringstream ostr;
+            Poco::XML::DOMWriter().writeNode(ostr, rws_result.p_xml_document);
+            return ostr.str() ;
+        }
+        return "";
+    }
+};
+
+//thin wrappers for functions with default values
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getMechanicalUnitRobTarget_overloads, RWSInterface::getMechanicalUnitRobTarget, 2, 5)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(registerLocalUser_overloads, RWSInterface::registerLocalUser, 0, 3)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(registerRemoteUser_overloads, RWSInterface::registerRemoteUser, 0, 3)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getLogText_overloads, RWSInterface::getLogText, 0, 1)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getLogTextLatestEvent_overloads, RWSInterface::getLogTextLatestEvent, 0, 1)
+
+BOOST_PYTHON_MODULE(abb_librws)
+{
+
+    using namespace boost::python;
+
+    class_<std::vector<std::string> >("string_vector")
+        .def(vector_indexing_suite<std::vector<std::string> >())
+    ;
+
+    class_<std::vector<RWSInterface::RAPIDTaskInfo> >("RAPIDTaskInfo_vector")
+        .def(vector_indexing_suite<std::vector<RWSInterface::RAPIDTaskInfo> >())
+    ;
+
+    class_<std::vector<cfg::moc::Arm> >("Arm_vector")
+        .def(vector_indexing_suite<std::vector<cfg::moc::Arm> >())
+    ;
+
+    class_<std::vector<cfg::moc::Joint> >("Joint_vector")
+        .def(vector_indexing_suite<std::vector<cfg::moc::Joint> >())
+    ;
+
+    class_<std::vector<cfg::moc::MechanicalUnit> >("MechanicalUnit_vector")
+        .def(vector_indexing_suite<std::vector<cfg::moc::MechanicalUnit> >())
+    ;
+
+    class_<std::vector<cfg::sys::MechanicalUnitGroup> >("MechanicalUnitGroup_vector")
+        .def(vector_indexing_suite<std::vector<cfg::sys::MechanicalUnitGroup> >())
+    ;
+
+    class_<std::vector<cfg::sys::PresentOption> >("PresentOption_vector")
+        .def(vector_indexing_suite<std::vector<cfg::sys::PresentOption> >())
+    ;
+
+    class_<std::vector<cfg::moc::Robot> >("Robot_vector")
+        .def(vector_indexing_suite<std::vector<cfg::moc::Robot> >())
+    ;
+
+    class_<std::vector<cfg::moc::Single> >("Single_vector")
+        .def(vector_indexing_suite<std::vector<cfg::moc::Single> >())
+    ;
+
+    class_<std::vector<cfg::moc::Transmission> >("Transmission_vector")
+        .def(vector_indexing_suite<std::vector<cfg::moc::Transmission> >())
+    ;
+
+    class_<std::vector<RWSInterface::RAPIDModuleInfo> >("RAPIDModuleInfo_vector")
+        .def(vector_indexing_suite<std::vector<RWSInterface::RAPIDModuleInfo> >())
+    ;
+
+
+    enum_<TriBool::Values>("Motion")
+        .value("UNKNOWN_VALUE", TriBool::UNKNOWN_VALUE)
+        .value("TRUE_VALUE", TriBool::TRUE_VALUE)
+        .value("FALSE_VALUE", TriBool::FALSE_VALUE)
+    ;
+
+    class_<TriBool>("TriBool")
+        .def(init<TriBool::Values>())
+        .def(init<bool>())
+        .def("isUnknown", &TriBool::isUnknown)
+        .def("isTrue", &TriBool::isTrue)
+        .def("isFalse", &TriBool::isFalse)
+        .def("toString", &TriBool::toString)
+        .def("__str__", &TriBool::toString)
+        //TODO: Operator overrides
+    ;
+
+    /*rws_config*/
+    class_<cfg::moc::Arm, boost::noncopyable>("Arm", no_init)
+        .def_readwrite("name", &cfg::moc::Arm::name)
+        .def_readwrite("lower_joint_bound", &cfg::moc::Arm::lower_joint_bound)
+        .def_readwrite("upper_joint_bound", &cfg::moc::Arm::upper_joint_bound)
+    ;
+
+    class_<cfg::moc::Joint, boost::noncopyable>("Joint", no_init)
+        .def_readwrite("name", &cfg::moc::Joint::name)
+        .def_readwrite("logical_axis", &cfg::moc::Joint::logical_axis)
+        .def_readwrite("kinematic_axis_number", &cfg::moc::Joint::kinematic_axis_number)
+        .def_readwrite("use_arm", &cfg::moc::Joint::use_arm)
+        .def_readwrite("use_transmission", &cfg::moc::Joint::use_transmission)
+    ;
+
+    class_<cfg::moc::MechanicalUnit, boost::noncopyable>("MechanicalUnit", no_init)
+        .def_readwrite("name", &cfg::moc::MechanicalUnit::name)
+        .def_readwrite("use_robot", &cfg::moc::MechanicalUnit::use_robot)
+        .def_readwrite("use_singles", &cfg::moc::MechanicalUnit::use_singles)
+    ;
+
+    class_<cfg::moc::Robot, boost::noncopyable>("Robot", no_init)
+        .def_readwrite("name", &cfg::moc::Robot::name)
+        .def_readwrite("use_robot_type", &cfg::moc::Robot::use_robot_type)
+        .def_readwrite("use_joints", &cfg::moc::Robot::use_joints)
+        .def_readwrite("base_frame", &cfg::moc::Robot::base_frame)
+        .def_readwrite("base_frame_moved_by", &cfg::moc::Robot::base_frame_moved_by)
+    ;
+
+    class_<cfg::moc::Single, boost::noncopyable>("Single", no_init)
+        .def_readwrite("name", &cfg::moc::Single::name)
+        .def_readwrite("use_single_type", &cfg::moc::Single::use_single_type)
+        .def_readwrite("use_joint", &cfg::moc::Single::use_joint)
+        .def_readwrite("base_frame", &cfg::moc::Single::base_frame)
+        .def_readwrite("base_frame_coordinated", &cfg::moc::Single::base_frame_coordinated)
+    ;
+
+    class_<cfg::moc::Transmission, boost::noncopyable>("Transmission", no_init)
+        .def_readwrite("name", &cfg::moc::Transmission::name)
+        .def_readwrite("rotating_move", &cfg::moc::Transmission::rotating_move)
+    ;
+
+    class_<cfg::sys::MechanicalUnitGroup, boost::noncopyable>("MechanicalUnitGroup", no_init)
+        .def_readwrite("name", &cfg::sys::MechanicalUnitGroup::name)
+        .def_readwrite("robot", &cfg::sys::MechanicalUnitGroup::robot)
+        .def_readwrite("mechanical_units", &cfg::sys::MechanicalUnitGroup::mechanical_units)
+    ;
+
+    class_<cfg::sys::PresentOption, boost::noncopyable>("MechanicalUnitGroup", no_init)
+        .def_readwrite("name", &cfg::sys::PresentOption::name)
+        .def_readwrite("description", &cfg::sys::PresentOption::description)
+    ;
+
+    /*rws_client*/
+    class_<RWSClient::RAPIDSymbolResource, boost::noncopyable>("RAPIDSymbolResource", init<const std::string&, const std::string&>())
+        .def_readwrite("module", &RWSClient::RAPIDSymbolResource::module)
+        .def_readwrite("name", &RWSClient::RAPIDSymbolResource::name)
+    ;
+
+
+    class_<RWSClient::RAPIDResource, boost::noncopyable>("RAPIDResource", init<const std::string&, const std::string&, const std::string&>())
+        .def(init<const std::string&, const RWSClient::RAPIDSymbolResource&>())
+        .def_readwrite("task", &RWSClient::RAPIDResource::task)
+        .def_readwrite("module", &RWSClient::RAPIDResource::module)
+        .def_readwrite("name", &RWSClient::RAPIDResource::name)
+    ;
+
+    class_<RWSClient::FileResource, boost::noncopyable>("FileResource", init<const std::string&>())
+        .def(init<const std::string&, const std::string&>())
+        .def_readwrite("filename", &RWSClient::FileResource::filename)
+        .def_readwrite("directory", &RWSClient::FileResource::directory)
+    ;
+
+    enum_<RWSClient::SubscriptionResources::Priority>("Priority")
+        .value("LOW", RWSClient::SubscriptionResources::LOW)
+        .value("MEDIUM", RWSClient::SubscriptionResources::MEDIUM)
+        .value("HIGH", RWSClient::SubscriptionResources::HIGH)
+    ;
+
+    class_<RWSClient::SubscriptionResources::SubscriptionResource, boost::noncopyable>("SubscriptionResource", init<const std::string&, const RWSClient::SubscriptionResources::Priority>())
+        .def_readwrite("resource_uri", &RWSClient::SubscriptionResources::SubscriptionResource::resource_uri)
+        .def_readwrite("priority", &RWSClient::SubscriptionResources::SubscriptionResource::priority)
+    ;
+
+    class_<RWSClient::SubscriptionResources>("SubscriptionResources")
+        .def("add", &RWSClient::SubscriptionResources::add)
+        .def("addIOSignal", &RWSClient::SubscriptionResources::addIOSignal)
+        .def("addRAPIDPersistantVariable", &RWSClient::SubscriptionResources::addRAPIDPersistantVariable)
+        //.def("getResources", &RWSClient::SubscriptionResources::getResources)
+    ;
+
+    enum_<RWSClient::Coordinate>("Coordinate")
+        .value("BASE", RWSClient::BASE)
+        .value("WORLD", RWSClient::WORLD)
+        .value("TOOL", RWSClient::TOOL)
+        .value("WOBJ", RWSClient::WOBJ)
+        .value("ACTIVE", RWSClient::ACTIVE)
+    ;
+
+
+    /*rws_rapid*/
+
+    class_<RAPIDSymbolDataAbstract, boost::noncopyable>("RAPIDSymbolDataAbstract", no_init)
+        .def("getType", &RAPIDSymbolDataAbstract::getType)
+        .def("parseString", &RAPIDSymbolDataAbstract::parseString)
+        .def("constructString", &RAPIDSymbolDataAbstract::constructString)
+        .def("__str__", &RAPIDSymbolDataAbstract::constructString)
+    ;
+
+    class_<RAPIDBool, bases<RAPIDSymbolDataAbstract> >("RAPIDBool", init<>())
+        .def(init<const bool>())
+    ;
+
+    implicitly_convertible<bool, RAPIDBool>();
+
+    class_<RAPIDNum, bases<RAPIDSymbolDataAbstract> >("RAPIDNum", init<>())
+        .def(init<const float>())
+    ;
+
+    implicitly_convertible<float,RAPIDNum>();
+
+    class_<RAPIDDnum, bases<RAPIDSymbolDataAbstract> >("RAPIDDnum", init<>())
+        .def(init<const double>())
+    ;
+
+    implicitly_convertible<float,RAPIDDnum>();
+
+    class_<RAPIDString, bases<RAPIDSymbolDataAbstract> >("RAPIDString", init<>())
+        .def(init<const std::string&>())
+    ;
+
+    implicitly_convertible<std::string,RAPIDString>();
+
+
+    class_<RAPIDRecord, bases<RAPIDSymbolDataAbstract> >("RAPIDRecord", init<const std::string&>())
+
+    ;
+
+    class_<PyRAPIDRecord, bases<RAPIDRecord> >("PyRAPIDRecord", init<const std::string&>())
+        .def<void (PyRAPIDRecord::*)(RAPIDSymbolDataAbstract*)>("addComponents", &PyRAPIDRecord::addComponents)
+
+    ;
+
+    class_<RobJoint, bases<RAPIDRecord> >("RobJoint", init<>())
+        .def_readwrite("rax_1", &RobJoint::rax_1)
+        .def_readwrite("rax_2", &RobJoint::rax_2)
+        .def_readwrite("rax_3", &RobJoint::rax_3)
+        .def_readwrite("rax_4", &RobJoint::rax_4)
+        .def_readwrite("rax_5", &RobJoint::rax_5)
+        .def_readwrite("rax_6", &RobJoint::rax_6)
+    ;
+
+    class_<ExtJoint, bases<RAPIDRecord> >("ExtJoint", init<>())
+        .def_readwrite("eax_a", &ExtJoint::eax_a)
+        .def_readwrite("eax_b", &ExtJoint::eax_b)
+        .def_readwrite("eax_c", &ExtJoint::eax_c)
+        .def_readwrite("eax_d", &ExtJoint::eax_d)
+        .def_readwrite("eax_e", &ExtJoint::eax_e)
+        .def_readwrite("eax_f", &ExtJoint::eax_f)
+    ;
+
+    class_<JointTarget, bases<RAPIDRecord> >("JointTarget", init<>())
+        .def(init<const JointTarget&>())
+        .def_readwrite("robax", &JointTarget::robax)
+        .def_readwrite("extax", &JointTarget::extax)
+    ;
+
+    class_<Pos, bases<RAPIDRecord> >("Pos", init<>())
+        .def_readwrite("x", &Pos::x)
+        .def_readwrite("y", &Pos::y)
+        .def_readwrite("z", &Pos::z)
+    ;
+
+    class_<Orient, bases<RAPIDRecord> >("Orient", init<>())
+        .def_readwrite("q1", &Orient::q1)
+        .def_readwrite("q2", &Orient::q2)
+        .def_readwrite("q3", &Orient::q3)
+        .def_readwrite("q4", &Orient::q4)
+    ;
+
+    class_<Pose, bases<RAPIDRecord> >("Pose", init<>())
+        .def(init<const Pose&>())
+        .def_readwrite("pos", &Pose::pos)
+        .def_readwrite("rot", &Pose::rot)
+    ;
+
+    class_<ConfData, bases<RAPIDRecord> >("ConfData", init<>())
+        .def_readwrite("q1", &ConfData::cf1)
+        .def_readwrite("q2", &ConfData::cf4)
+        .def_readwrite("q3", &ConfData::cf6)
+        .def_readwrite("q4", &ConfData::cfx)
+    ;
+
+    class_<RobTarget, bases<RAPIDRecord> >("RobTarget", init<>())
+        .def(init<const RobTarget&>())
+        .def_readwrite("pos", &RobTarget::pos)
+        .def_readwrite("orient", &RobTarget::orient)
+        .def_readwrite("robconf", &RobTarget::robconf)
+        .def_readwrite("extax", &RobTarget::extax)
+    ;
+
+    class_<LoadData, bases<RAPIDRecord> >("LoadData", init<>())
+        .def(init<const LoadData&>())
+        .def_readwrite("mass", &LoadData::mass)
+        .def_readwrite("cog", &LoadData::cog)
+        .def_readwrite("aom", &LoadData::aom)
+        .def_readwrite("ix", &LoadData::ix)
+        .def_readwrite("iy", &LoadData::iy)
+        .def_readwrite("iz", &LoadData::iz)
+    ;
+
+    class_<ToolData, bases<RAPIDRecord> >("ToolData", init<>())
+        .def(init<const ToolData&>())
+        .def_readwrite("robhold", &ToolData::robhold)
+        .def_readwrite("tframe", &ToolData::tframe)
+        .def_readwrite("tload", &ToolData::tload)
+    ;
+
+    class_<WObjData, bases<RAPIDRecord> >("WObjData", init<>())
+        .def(init<const WObjData&>())
+        .def_readwrite("robhold", &WObjData::robhold)
+        .def_readwrite("ufprog", &WObjData::ufprog)
+        .def_readwrite("ufmec", &WObjData::ufmec)
+        .def_readwrite("uframe", &WObjData::uframe)
+        .def_readwrite("oframe", &WObjData::oframe)
+    ;
+
+    class_<SpeedData, bases<RAPIDRecord> >("SpeedData", init<>())
+        .def_readwrite("v_tcp", &SpeedData::v_tcp)
+        .def_readwrite("v_ori", &SpeedData::v_ori)
+        .def_readwrite("v_leax", &SpeedData::v_leax)
+        .def_readwrite("v_reax", &SpeedData::v_reax)
+    ;
+
+    /* RWSInterface */
+    enum_<RWSInterface::RAPIDTaskExecutionState>("RAPIDTaskExecutionState")
+        .value("UNKNOWN", RWSInterface::UNKNOWN)
+        .value("READY", RWSInterface::READY)
+        .value("STOPPED", RWSInterface::STOPPED)
+        .value("STARTED", RWSInterface::STARTED)
+        .value("UNINITIALIZED", RWSInterface::UNINITIALIZED)
+    ;
+
+    enum_<RWSInterface::MechanicalUnitType>("MechanicalUnitType")
+        .value("NONE", RWSInterface::NONE)
+        .value("TCP_ROBOT", RWSInterface::TCP_ROBOT)
+        .value("ROBOT", RWSInterface::ROBOT)
+        .value("SINGLE", RWSInterface::SINGLE)
+        .value("UNDEFINED", RWSInterface::UNDEFINED)
+    ;
+
+    enum_<RWSInterface::MechanicalUnitMode>("MechanicalUnitMode")
+        .value("UNKNOWN_MODE", RWSInterface::UNKNOWN_MODE)
+        .value("ACTIVATED", RWSInterface::ACTIVATED)
+        .value("DEACTIVATED", RWSInterface::DEACTIVATED)
+    ;
+
+    class_<RWSInterface::MechanicalUnitStaticInfo>("MechanicalUnitStaticInfo")
+        .def_readwrite("type", &RWSInterface::MechanicalUnitStaticInfo::type)
+        .def_readwrite("task_name", &RWSInterface::MechanicalUnitStaticInfo::task_name)
+        .def_readwrite("axes", &RWSInterface::MechanicalUnitStaticInfo::axes)
+        .def_readwrite("axes_total", &RWSInterface::MechanicalUnitStaticInfo::axes_total)
+        .def_readwrite("is_integrated_unit", &RWSInterface::MechanicalUnitStaticInfo::is_integrated_unit)
+        .def_readwrite("has_integrated_unit", &RWSInterface::MechanicalUnitStaticInfo::has_integrated_unit)
+    ;
+
+    class_<RWSInterface::MechanicalUnitDynamicInfo>("MechanicalUnitDynamicInfo")
+        .def_readwrite("tool_name", &RWSInterface::MechanicalUnitDynamicInfo::tool_name)
+        .def_readwrite("wobj_name", &RWSInterface::MechanicalUnitDynamicInfo::wobj_name)
+        .def_readwrite("payload_name", &RWSInterface::MechanicalUnitDynamicInfo::payload_name)
+        .def_readwrite("total_payload_name", &RWSInterface::MechanicalUnitDynamicInfo::total_payload_name)
+        .def_readwrite("status", &RWSInterface::MechanicalUnitDynamicInfo::status)
+        .def_readwrite("mode", &RWSInterface::MechanicalUnitDynamicInfo::mode)
+        .def_readwrite("jog_mode", &RWSInterface::MechanicalUnitDynamicInfo::jog_mode)
+        .def_readwrite("coord_system", &RWSInterface::MechanicalUnitDynamicInfo::coord_system)
+    ;
+
+    class_<RWSInterface::SystemInfo>("SystemInfo")
+        .def_readwrite("robot_ware_version", &RWSInterface::SystemInfo::robot_ware_version)
+        .def_readwrite("system_name", &RWSInterface::SystemInfo::system_name)
+        .def_readwrite("system_type", &RWSInterface::SystemInfo::system_type)
+        .def_readwrite("system_options", &RWSInterface::SystemInfo::system_options)
+    ;
+
+    class_<RWSInterface::RobotWareOptionInfo>("RobotWareOptionInfo", init<std::string&, std::string&>())
+        .def_readwrite("name", &RWSInterface::RobotWareOptionInfo::name)
+        .def_readwrite("description", &RWSInterface::RobotWareOptionInfo::description)
+    ;
+
+    class_<RWSInterface::RAPIDModuleInfo>("RAPIDModuleInfo", init<std::string&, std::string&>())
+        .def_readwrite("name", &RWSInterface::RAPIDModuleInfo::name)
+        .def_readwrite("type", &RWSInterface::RAPIDModuleInfo::type)
+    ;
+
+    class_<RWSInterface::RAPIDTaskInfo>("RAPIDTaskInfo", init<const std::string&, const bool, const bool, const RWSInterface::RAPIDTaskExecutionState>())
+        .def_readwrite("name", &RWSInterface::RAPIDTaskInfo::name)
+        .def_readwrite("is_motion_task", &RWSInterface::RAPIDTaskInfo::is_motion_task)
+        .def_readwrite("is_active", &RWSInterface::RAPIDTaskInfo::is_active)
+        .def_readwrite("execution_state", &RWSInterface::RAPIDTaskInfo::execution_state)
+    ;
+
+    class_<RWSInterface::StaticInfo>("StaticInfo")
+        .def_readwrite("rapid_tasks", &RWSInterface::StaticInfo::rapid_tasks)
+        .def_readwrite("system_info", &RWSInterface::StaticInfo::system_info)
+    ;
+
+    class_<RWSInterface::RuntimeInfo>("RuntimeInfo")
+        .def_readwrite("auto_mode", &RWSInterface::RuntimeInfo::auto_mode)
+        .def_readwrite("motors_on", &RWSInterface::RuntimeInfo::motors_on)
+        .def_readwrite("rapid_running", &RWSInterface::RuntimeInfo::rapid_running)
+        .def_readwrite("rws_connected", &RWSInterface::RuntimeInfo::rws_connected)
+    ;
+
+    class_<RWSInterfacePy, boost::noncopyable>("RWSInterface", init<const std::string&>())
+        .def(init<std::string&, std::string&, std::string&>())
+        .def(init<std::string&, unsigned short>())
+        .def(init<std::string&, unsigned short, std::string&, std::string&>())
+
+        .def("collectRuntimeInfo", &RWSInterfacePy::collectRuntimeInfo)
+        .def("collectStaticInfo", &RWSInterfacePy::collectStaticInfo)
+        .def("getCFGArms", &RWSInterfacePy::getCFGArms)
+        .def("getCFGJoints", &RWSInterfacePy::getCFGJoints)
+        .def("getCFGMechanicalUnits", &RWSInterfacePy::getCFGMechanicalUnits)
+        .def("getCFGMechanicalUnitGroups", &RWSInterfacePy::getCFGMechanicalUnitGroups)
+        .def("getCFGPresentOptions", &RWSInterfacePy::getCFGPresentOptions)
+        .def("getCFGRobots", &RWSInterfacePy::getCFGRobots)
+        .def("getCFGSingles", &RWSInterfacePy::getCFGSingles)
+        .def("getCFGTransmission", &RWSInterfacePy::getCFGTransmission)
+        //Deprecated
+        //.def("getPresentRobotWareOptions", &RWSInterface::getPresentRobotWareOptions)
+        .def("getIOSignal", &RWSInterfacePy::getIOSignal)
+        .def("getMechanicalUnitStaticInfo", &RWSInterfacePy::getMechanicalUnitStaticInfo)
+        .def("getMechanicalUnitDynamicInfo", &RWSInterfacePy::getMechanicalUnitDynamicInfo)
+        .def("getMechanicalUnitJointTarget", &RWSInterfacePy::getMechanicalUnitJointTarget)
+
+        .def<bool (RWSInterfacePy::*)(const std::string&, RobTarget*, const RWSClient::Coordinate&,
+                                      const std::string&, const std::string&)>("getMechanicalUnitRobTarget",
+                                      &RWSInterfacePy::getMechanicalUnitRobTarget, getMechanicalUnitRobTarget_overloads(
+                                      (arg("mechunit"), arg("p_robtarget"), arg("coordinate") = RWSClient::ACTIVE,
+                                      arg("tool") = "", arg("wobj") = "")))
+
+
+        .def<std::string (RWSInterfacePy::*)(const std::string&, const std::string&, const std::string&)>("getRAPIDSymbolData", &RWSInterfacePy::getRAPIDSymbolData)
+        .def<bool (RWSInterfacePy::*)(const std::string&, const std::string&, const std::string&, RAPIDSymbolDataAbstract*)>("getRAPIDSymbolData", &RWSInterfacePy::getRAPIDSymbolData)
+        .def<bool (RWSInterfacePy::*)(const std::string&, const RWSClient::RAPIDSymbolResource&, RAPIDSymbolDataAbstract*)>("getRAPIDSymbolData", &RWSInterfacePy::getRAPIDSymbolData)
+
+        .def("getRAPIDModulesInfo", &RWSInterfacePy::getRAPIDModulesInfo)
+        .def("getRAPIDTasks", &RWSInterfacePy::getRAPIDTasks)
+        .def("getSpeedRatio", &RWSInterfacePy::getSpeedRatio)
+        .def("getSystemInfo", &RWSInterfacePy::getSystemInfo)
+        .def("isAutoMode", &RWSInterfacePy::isAutoMode)
+        .def("isMotorsOn", &RWSInterfacePy::isMotorsOn)
+        .def("isRAPIDRunning", &RWSInterfacePy::isRAPIDRunning)
+        .def("setIOSignal", &RWSInterfacePy::setIOSignal)
+
+        .def<bool (RWSInterfacePy::*)(const std::string&, const std::string&, const std::string&, const std::string&)>("setRAPIDSymbolData", &RWSInterfacePy::setRAPIDSymbolData)
+        .def<bool (RWSInterfacePy::*)(const std::string&, const std::string&, const std::string&, const RAPIDSymbolDataAbstract&)>("setRAPIDSymbolData", &RWSInterfacePy::setRAPIDSymbolData)
+        .def<bool (RWSInterfacePy::*)(const std::string&, const RWSClient::RAPIDSymbolResource&, const RAPIDSymbolDataAbstract&)>("setRAPIDSymbolData", &RWSInterfacePy::setRAPIDSymbolData)
+
+        .def("startRAPIDExecution", &RWSInterfacePy::startRAPIDExecution)
+        .def("stopRAPIDExecution", &RWSInterfacePy::stopRAPIDExecution)
+        .def("resetRAPIDProgramPointer", &RWSInterfacePy::resetRAPIDProgramPointer)
+        .def("setMotorsOn", &RWSInterfacePy::setMotorsOn)
+        .def("setMotorsOff", &RWSInterfacePy::setMotorsOff)
+        .def("setSpeedRatio", &RWSInterfacePy::setSpeedRatio)
+        .def("getFile", &RWSInterfacePy::getFile)
+        .def("uploadFile", &RWSInterfacePy::uploadFile)
+        .def("deleteFile", &RWSInterfacePy::deleteFile)
+        .def("startSubscription", &RWSInterfacePy::startSubscription)
+        .def<bool (RWSInterfacePy::*)()>("waitForSubscriptionEvent", &RWSInterfacePy::waitForSubscriptionEvent)
+        //.def<bool (RWSInterface::*)(Poco::AutoPtr<Poco::XML::Document>*)>("waitForSubscriptionEvent", &RWSInterface::waitForSubscriptionEvent)
+        .def("waitForSubscriptionEventAsString", &RWSInterfacePy::waitForSubscriptionEventAsString)
+        .def("endSubscription", &RWSInterfacePy::endSubscription)
+        .def("forceCloseSubscription", &RWSInterfacePy::forceCloseSubscription)
+        .def<bool (RWSInterfacePy::*)(const std::string&, const std::string&, const std::string&)>("registerLocalUser", &RWSInterfacePy::registerLocalUser,
+                                      registerLocalUser_overloads((arg("username") = SystemConstants::General::DEFAULT_USERNAME,
+                                                                   arg("application") = SystemConstants::General::EXTERNAL_APPLICATION,
+                                                                   arg("location") = SystemConstants::General::EXTERNAL_LOCATION)))
+        .def<bool (RWSInterfacePy::*)(const std::string&, const std::string&, const std::string&)>("registerRemoteUser", &RWSInterfacePy::registerRemoteUser,
+                                      registerRemoteUser_overloads((arg("username") = SystemConstants::General::DEFAULT_USERNAME,
+                                                                    arg("application") = SystemConstants::General::EXTERNAL_APPLICATION,
+                                                                    arg("location") = SystemConstants::General::EXTERNAL_LOCATION)))
+        .def<std::string (RWSInterfacePy::*)(const bool)>("getLogText", &RWSInterfacePy::getLogText, getLogText_overloads((arg("verbose") = false)))
+        .def<std::string (RWSInterfacePy::*)(const bool)>("getLogTextLatestEvent", &RWSInterfacePy::getLogTextLatestEvent, getLogTextLatestEvent_overloads((arg("verbose") = false)))
+        .def("setHTTPTimeout", &RWSInterfacePy::setHTTPTimeout)
+    ;
+}

--- a/test/test_python.py
+++ b/test/test_python.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python
+
+import abb_librws as abb
+import sys
+import time
+
+
+class TRecord(abb.PyRAPIDRecord):
+    def __init__(self):
+        abb.PyRAPIDRecord.__init__(self, "TRecord")
+        self.Value = abb.RAPIDNum()
+        self.StringValue = abb.RAPIDString()
+        self.addComponents(self.Value)
+        self.addComponents(self.StringValue)
+
+
+rws = abb.RWSInterface(sys.argv[1])
+start = time.time()
+ri = rws.collectRuntimeInfo()
+print("Runtime info")
+print("------------")
+print("Auto mode: {}\nMotors on {}\nRapid running {}\nRws connected {}".format(ri.auto_mode, ri.motors_on, ri.rapid_running, ri.rws_connected))
+
+si = rws.collectStaticInfo()
+print("")
+print("System Info")
+print("-----------")
+print("System name: {}".format(si.system_info.system_name))
+print("System type: {}".format(si.system_info.system_type))
+print("Robotware version: {}".format(si.system_info.robot_ware_version))
+print("System options: {}".format(list(si.system_info.system_options)))
+for rapid_task in si.rapid_tasks:
+    print("Task: name {}".format(rapid_task.name))
+print("")
+
+arms = rws.getCFGArms()
+for arm in arms:
+    print("name: {}\tlower bound: {}\tupper_bound {}".format(arm.name, arm.lower_joint_bound, arm.upper_joint_bound))
+
+
+mechanical_units = rws.getCFGMechanicalUnits()
+mechanical_unit_groups = rws.getCFGMechanicalUnitGroups()
+present_options = rws.getCFGPresentOptions()
+robots = rws.getCFGRobots()
+singles = rws.getCFGSingles()
+transmissions = rws.getCFGTransmission()
+# deprecated
+# robotware_option_info = rws.getPresentRobotWareOptions()
+
+mechanical_unit_static_info = abb.MechanicalUnitStaticInfo()
+success = rws.getMechanicalUnitStaticInfo("ROB_1", mechanical_unit_static_info)
+if success:
+    print("")
+    print("Mechanical Unit Static Info")
+    print("----------------------------")
+    print("Type: {}".format(mechanical_unit_static_info.type))
+    print("Task name: {}".format(mechanical_unit_static_info.task_name))
+    print("Axes: {}".format(mechanical_unit_static_info.axes))
+    print("Axes total: {}".format(mechanical_unit_static_info.axes_total))
+    print("is Integrated Unit: {}".format(mechanical_unit_static_info.is_integrated_unit))
+    print("has Integrated Unit: {}".format(mechanical_unit_static_info.has_integrated_unit))
+    print("")
+    pass
+
+mechanical_unit_dynamic_info = abb.MechanicalUnitDynamicInfo()
+success = rws.getMechanicalUnitDynamicInfo("ROB_1", mechanical_unit_dynamic_info)
+if success:
+    print("")
+    print("Mechanical Unit Dynamic Info")
+    print("----------------------------")
+    print("Tool name: {}".format(mechanical_unit_dynamic_info.tool_name))
+    print("Wobj name: {}".format(mechanical_unit_dynamic_info.wobj_name))
+    print("Payload name: {}".format(mechanical_unit_dynamic_info.payload_name))
+    print("Total payload name: {}".format(mechanical_unit_dynamic_info.total_payload_name))
+    print("Status: {}".format(mechanical_unit_dynamic_info.status))
+    print("Mode: {}".format(mechanical_unit_dynamic_info.mode))
+    print("Jog mode: {}".format(mechanical_unit_dynamic_info.jog_mode))
+    print("Coordinate System: {}".format(mechanical_unit_dynamic_info.coord_system))
+    print("")
+
+jointtarget = abb.JointTarget()
+success = rws.getMechanicalUnitJointTarget("ROB_1", jointtarget)
+if success:
+    print("Jointtarget is {}".format(jointtarget))
+
+robtarget = abb.RobTarget()
+success = rws.getMechanicalUnitRobTarget("ROB_1", robtarget)
+if success:
+    print("RobTarget is {}".format(robtarget))
+    pass
+
+# Iterate through all tasks and go through modules and print their info
+rapid_tasks = rws.getRAPIDTasks();
+for rapid_task in rapid_tasks:
+    module_infos = rws.getRAPIDModulesInfo(rapid_task.name)
+    for module_info in module_infos:
+        print("Module: {}, type: {}".format(module_info.name, module_info.type))
+
+speed_ratio = rws.getSpeedRatio()
+print("Speed ratio: {}".format(speed_ratio))
+
+logText = rws.getLogText()
+print("log Text: {}".format(logText))
+
+logTextverbose = rws.getLogText(True)
+print("log Text Verbose: {}".format(logTextverbose))
+
+# --------------------------
+# tests for data types
+# --------------------------
+#bool
+testBool = abb.RAPIDBool()
+success = rws.getRAPIDSymbolData("T_ROB1", "ABB_LIBRWS", "testBool", testBool)
+if success:
+    print("Value of testBool is: {}".format(testBool))
+#num
+testNum = abb.RAPIDNum()
+success = rws.getRAPIDSymbolData("T_ROB1", "ABB_LIBRWS", "testNum", testNum)
+if success:
+    print("Value of testNum is: {}".format(testNum))
+#string
+testString = abb.RAPIDString()
+success = rws.getRAPIDSymbolData("T_ROB1", "ABB_LIBRWS", "testString", testString)
+if success:
+    print("Value of testString is: {}".format(testString))
+#RobJoint
+testRobJoint = abb.RobJoint()
+success = rws.getRAPIDSymbolData("T_ROB1", "ABB_LIBRWS", "testRobJoint", testRobJoint)
+if success:
+    print("Value of testRobJoint is: {}".format(testRobJoint))
+#ExtJoint
+testExtJoint = abb.ExtJoint()
+success = rws.getRAPIDSymbolData("T_ROB1", "ABB_LIBRWS", "testExtJoint", testExtJoint)
+if success:
+    print("Value of testNum is: {}".format(testExtJoint))
+#JointTarget
+testJointTarget = abb.JointTarget()
+success = rws.getRAPIDSymbolData("T_ROB1", "ABB_LIBRWS", "testJointTarget", testJointTarget)
+if success:
+    print("Value of testJointTarget is: {}".format(testJointTarget))
+#Pos
+testPos = abb.Pos()
+success = rws.getRAPIDSymbolData("T_ROB1", "ABB_LIBRWS", "testPos", testPos)
+if success:
+    print("Value of testPos is: {}".format(testPos))
+#Orient
+testOrient = abb.Orient()
+success = rws.getRAPIDSymbolData("T_ROB1", "ABB_LIBRWS", "testOrient", testOrient)
+if success:
+    print("Value of testOrient is: {}".format(testOrient))
+#Pose
+testPose = abb.Pose()
+success = rws.getRAPIDSymbolData("T_ROB1", "ABB_LIBRWS", "testPose", testPose)
+if success:
+    print("Value of testPose is: {}".format(testPose))
+#ConfData
+testConfData = abb.ConfData()
+success = rws.getRAPIDSymbolData("T_ROB1", "ABB_LIBRWS", "testConfData", testConfData)
+if success:
+    print("Value of testConfData is: {}".format(testConfData))
+#RobTarget
+testRobTarget = abb.RobTarget()
+success = rws.getRAPIDSymbolData("T_ROB1", "ABB_LIBRWS", "testRobTarget", testRobTarget)
+if success:
+    print("Value of testRobTarget is: {}".format(testRobTarget))
+#ToolData
+testToolData = abb.ToolData()
+success = rws.getRAPIDSymbolData("T_ROB1", "ABB_LIBRWS", "testToolData", testToolData)
+if success:
+    print("Value of testToolData is: {}".format(testToolData))
+#WObjData
+testWObjData = abb.WObjData()
+success = rws.getRAPIDSymbolData("T_ROB1", "ABB_LIBRWS", "testWObjData", testWObjData)
+if success:
+    print("Value of testWObjData is: {}".format(testWObjData))
+#SpeedData
+testSpeedData = abb.SpeedData()
+success = rws.getRAPIDSymbolData("T_ROB1", "ABB_LIBRWS", "testSpeedData", testSpeedData)
+if success:
+    print("Value of testSpeedData is: {}".format(testSpeedData))
+#LoadData
+testLoadData = abb.LoadData()
+success = rws.getRAPIDSymbolData("T_ROB1", "ABB_LIBRWS", "testLoadData", testLoadData)
+if success:
+    print("Value of testLoadData is: {}".format(testLoadData))
+#CustomRecord
+testRecord = rws.getRAPIDSymbolData("T_ROB1", "ABB_LIBRWS", "testRecord")
+print("Value of testRecord is: {}".format(testRecord))
+
+record = TRecord()
+record.parseString(testRecord)
+print("Value of record is: {}".format(record))
+
+print("Total time is {}".format(time.time() - start))

--- a/test/test_robot.mod
+++ b/test/test_robot.mod
@@ -1,0 +1,24 @@
+MODULE ABB_LIBRWS
+    RECORD tRecord
+        Num Value;
+        String stringValue;
+    ENDRECORD
+   
+    TASK PERS bool testBool := TRUE;
+    TASK PERS num testNum := 123;
+    TASK PERS string testString := "Hello World";
+    TASK PERS robJoint testRobJoint := [1,2,3,4,5,6];
+    TASK PERS ExtJoint testExtJoint := [1,2,3,4,5,6];
+    TASK PERS JointTarget testJointTarget := [[1,2,3,4,5,6],[1,2,3,4,5,6]];
+    TASK PERS Pos testPos :=[1,2,3];
+    TASK PERS Orient testOrient := [1,0,0,0];
+    TASK PERS Pose testPose :=[[1,2,3],[1,0,0,0]];
+    TASK PERS ConfData testConfData := [1,2,3,4];
+    TASK PERS RobTarget testRobTarget := [[1,2,3],[1,0,0,0],[0,0,0,0],[0,0,0,0,0,0]];
+    TASK PERS ToolData testToolData := [TRUE, [[0, 0, 0], [1, 0, 0, 0]], [0.001, [0, 0, 0.001],[1, 0, 0, 0], 0, 0, 0]];
+    TASK PERS WobjData testWobjData := [FALSE, TRUE, "", [[1, 2, 3],[1, 0, 0, 0]],[[0, 0, 0],[1, 0, 0, 0]]];
+    TASK PERS SpeedData testSpeedData := [1,0,0,0];
+    TASK PERS LoadData testLoadData := [0.001, [0, 0, 0.001],[1, 0, 0, 0], 0, 0, 0];
+   
+    TASK PERS tRecord testREcord := [1, "Hello World"];
+ENDMODULE


### PR DESCRIPTION
This adds python wrappers to abb_librws using boost.python
We made this compatible for both python2 and python3 (compiles and imports correctly in a catkin workspace regardless of which python version you are using) but please also test it in different distros and setups to verify that it works.
Included there is a ABB robot module and a python test script that you can use to verify the functionality of the wrapper for your setup.

To run the test script in a catkin workspace you can use rosrun (though it is not required)
```bash
rosrun --prefix 'python2' abb_librws test_python.py 192.168.0.10
rosrun --prefix 'python3' abb_librws test_python.py 192.168.0.10
```
To run it without rosrun, you must have sourced the catkin workspace (to extent PYTHONPATH)
```
python2 src/abb_librws/test/test_python.py 192.168.0.10
python3 src/abb_librws/test/test_python.py 192.168.0.10
```