### PR TITLE
readme: use GHA badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # abb_librws
 
-[![Travis CI Status](https://travis-ci.com/ros-industrial/abb_librws.svg?branch=master)](https://travis-ci.com/ros-industrial/abb_librws)
+[![Build Status: Ubuntu Bionic (Actions)](https://github.com/ros-industrial/abb_librws/workflows/CI%20-%20Ubuntu%20Bionic/badge.svg?branch=master)](https://github.com/ros-industrial/abb_librws/actions?query=workflow%3A%22CI+-+Ubuntu+Bionic%22)
+[![Build Status: Ubuntu Focal (Actions)](https://github.com/ros-industrial/abb_librws/workflows/CI%20-%20Ubuntu%20Focal/badge.svg?branch=master)](https://github.com/ros-industrial/abb_librws/actions?query=workflow%3A%22CI+-+Ubuntu+Focal%22)
+
 [![license - bsd 3 clause](https://img.shields.io/:license-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
+
 [![support level: vendor](https://img.shields.io/badge/support%20level-vendor-brightgreen.svg)](http://rosindustrial.org/news/2016/10/7/better-supporting-a-growing-ros-industrial-software-platform)
 
 ## Important Notes

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status: Ubuntu Bionic (Actions)](https://github.com/ros-industrial/abb_librws/workflows/CI%20-%20Ubuntu%20Bionic/badge.svg?branch=master)](https://github.com/ros-industrial/abb_librws/actions?query=workflow%3A%22CI+-+Ubuntu+Bionic%22)
 [![Build Status: Ubuntu Focal (Actions)](https://github.com/ros-industrial/abb_librws/workflows/CI%20-%20Ubuntu%20Focal/badge.svg?branch=master)](https://github.com/ros-industrial/abb_librws/actions?query=workflow%3A%22CI+-+Ubuntu+Focal%22)
+[![Github Issues](https://img.shields.io/github/issues/ros-industrial/abb_librws.svg)](http://github.com/ros-industrial/abb_librws/issues)
 
 [![license - bsd 3 clause](https://img.shields.io/:license-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 


### PR DESCRIPTION
As per subject.

---

Edit: updated PR, readme now has 3 lines of badges, similar to `abb_robot_driver`:

![image](https://user-images.githubusercontent.com/4550046/115844119-d3d7aa80-a41f-11eb-82d2-02d19af90652.png)

