### PR TITLE
Use CMake imported targets to link Poco

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,11 +51,10 @@ generate_export_header(${PROJECT_NAME})
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include;${CMAKE_CURRENT_BINARY_DIR}>"
   $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>
-  ${Poco_INCLUDE_DIRS}
 )
 
 target_link_libraries(${PROJECT_NAME} PUBLIC
-  ${Poco_LIBRARIES}
+  Poco::Foundation Poco::Net Poco::Util Poco::XML
 )
 
 if(NOT BUILD_SHARED_LIBS)


### PR DESCRIPTION
The use of CMake imported targets to link Poco has the following advantages:


* It generated relocatable cmake config files (see https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html#creating-relocatable-packages)

* It does not raise an error like:

~~~
CMake Error in build/_deps/abb_librws-src/CMakeLists.txt:
  Target "abb_librws" INTERFACE_INCLUDE_DIRECTORIES property contains path:

    "C:/Users/gcorrenti/idjl-software/.pixi/envs/idjllancedeformationenv/Library/include"

  which is prefixed in the source directory.
~~~

when the `abb_librws` is installed in a folder that is contained in source folder of the cmake project that is calling `find_package(abb_librws)`, as it commonly happens if Poco is installed in a project-oriented package manager, for example [pixi](https://pixi.sh/latest/) or [vcpkg when used in manifest mode](https://learn.microsoft.com/en-us/vcpkg/concepts/manifest-mode).

I checked in Ubuntu and Poco imported targets are available in Poco's apt packages at least since Ubuntu 18.04, so I think we should be safe w.r.t. to backward compatibility.


